### PR TITLE
Fix layout and viewports

### DIFF
--- a/canopy/examples/focusgym.rs
+++ b/canopy/examples/focusgym.rs
@@ -63,7 +63,7 @@ impl Node for Block {
                 vp.view.split_vertical(self.children.len() as u16)?
             };
             for i in 0..self.children.len() {
-                l.place(&mut self.children[i], vps[i])?;
+                l.place(&mut self.children[i], vp, vps[i])?;
             }
         }
         Ok(())

--- a/canopy/examples/intervals.rs
+++ b/canopy/examples/intervals.rs
@@ -112,9 +112,10 @@ impl Intervals {
 impl Node for Intervals {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
         l.fill(self, sz)?;
-        let (a, b) = self.vp().view.carve_vend(1);
-        l.place(&mut self.statusbar, b)?;
-        l.place(&mut self.content, a)?;
+        let vp = self.vp();
+        let (a, b) = vp.view.carve_vend(1);
+        l.place(&mut self.statusbar, vp, b)?;
+        l.place(&mut self.content, vp, a)?;
         Ok(())
     }
 

--- a/canopy/examples/listgym.rs
+++ b/canopy/examples/listgym.rs
@@ -45,7 +45,8 @@ impl ListItem for Block {
 impl Node for Block {
     fn layout(&mut self, l: &Layout, target: Expanse) -> Result<()> {
         let loc = Rect::new(2, 0, target.w.saturating_sub(2), target.h);
-        l.place(&mut self.child, loc)?;
+        let vp = self.vp();
+        l.place(&mut self.child, vp, loc)?;
 
         let vp = self.child.vp();
         let sz = Expanse {
@@ -128,9 +129,10 @@ impl ListGym {
 
 impl Node for ListGym {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
-        let (a, b) = self.vp().screen_rect().carve_vend(1);
-        l.place(&mut self.content, a)?;
-        l.place(&mut self.statusbar, b)?;
+        let vp = self.vp();
+        let (a, b) = vp.screen_rect().carve_vend(1);
+        l.place(&mut self.content, vp, a)?;
+        l.place(&mut self.statusbar, vp, b)?;
         l.fill(self, sz)?;
         Ok(())
     }

--- a/canopy/src/canopy.rs
+++ b/canopy/src/canopy.rs
@@ -580,12 +580,11 @@ impl Canopy {
                 n.render(self, &mut rndr)?;
 
                 // Now add regions managed by children to coverage
-                let escreen = n.vp().screen_rect();
                 n.children(&mut |n| {
                     if !n.is_hidden() {
                         let s = n.vp().screen_rect();
                         if !s.is_zero() {
-                            rndr.coverage.add(escreen);
+                            rndr.coverage.add(s);
                         }
                     }
                     Ok(())
@@ -798,6 +797,9 @@ impl Canopy {
     pub(crate) fn set_root_size(&mut self, size: Expanse, root: &mut dyn Node) -> Result<()> {
         self.root_size = Some(size);
         self.taint_tree(root);
+        // Apply layout immediately so viewport reflects the new size
+        let l = Layout {};
+        root.layout(&l, size)?;
         Ok(())
     }
 

--- a/canopy/src/geom/rect.rs
+++ b/canopy/src/geom/rect.rs
@@ -181,8 +181,8 @@ impl Rect {
             return Err(Error::Geometry("rebase of non-contained point".into()));
         }
         Ok(Point {
-            x: pt.x - self.tl.x,
-            y: pt.y - self.tl.y,
+            x: pt.x.saturating_sub(self.tl.x),
+            y: pt.y.saturating_sub(self.tl.y),
         })
     }
 

--- a/canopy/src/inspector/view.rs
+++ b/canopy/src/inspector/view.rs
@@ -12,9 +12,10 @@ pub struct View {
 
 impl Node for View {
     fn layout(&mut self, l: &Layout, _: Expanse) -> Result<()> {
-        let (a, b) = self.vp().view.carve_vstart(1);
-        l.place(&mut self.tabs, a)?;
-        l.place(&mut self.logs, b)?;
+        let vp = self.vp();
+        let (a, b) = vp.view.carve_vstart(1);
+        l.place(&mut self.tabs, vp, a)?;
+        l.place(&mut self.logs, vp, b)?;
         Ok(())
     }
 

--- a/canopy/src/layout.rs
+++ b/canopy/src/layout.rs
@@ -42,9 +42,11 @@ impl Layout {
     }
 
     /// Place a child in a given sub-rectangle of a parent's view.
-    pub fn place(&self, child: &mut dyn Node, loc: Rect) -> Result<()> {
+    pub fn place(&self, child: &mut dyn Node, parent_vp: ViewPort, loc: Rect) -> Result<()> {
         child.layout(self, loc.expanse())?;
-        child.__vp_mut().position = loc.tl;
+        child.__vp_mut().position = parent_vp
+            .position
+            .scroll(loc.tl.x as i16, loc.tl.y as i16);
         Ok(())
     }
 

--- a/canopy/src/root.rs
+++ b/canopy/src/root.rs
@@ -150,8 +150,8 @@ where
         let vp = self.vp();
         if self.inspector_active {
             let parts = vp.view.split_horizontal(2)?;
-            l.place(&mut self.inspector, parts[0])?;
-            l.place(&mut self.app, parts[1])?;
+            l.place(&mut self.inspector, vp, parts[0])?;
+            l.place(&mut self.app, vp, parts[1])?;
         } else {
             l.fit(&mut self.app, vp)?;
         };

--- a/canopy/src/tutils/ttree.rs
+++ b/canopy/src/tutils/ttree.rs
@@ -68,6 +68,9 @@ macro_rules! leaf {
             fn accept_focus(&mut self) -> bool {
                 true
             }
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)
+            }
             fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
                 r.text(
                     "any",
@@ -173,9 +176,10 @@ macro_rules! branch {
 
             fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
                 l.fill(self, sz)?;
-                let parts = self.vp().view.split_vertical(2)?;
-                l.place(&mut self.a, parts[0])?;
-                l.place(&mut self.b, parts[1])?;
+                let vp = self.vp();
+                let parts = vp.view.split_vertical(2)?;
+                l.place(&mut self.a, vp, parts[0])?;
+                l.place(&mut self.b, vp, parts[1])?;
                 Ok(())
             }
 
@@ -256,9 +260,10 @@ impl Node for R {
 
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
         l.fill(self, sz)?;
-        let parts = self.vp().view.split_horizontal(2)?;
-        l.place(&mut self.a, parts[0])?;
-        l.place(&mut self.b, parts[1])?;
+        let vp = self.vp();
+        let parts = vp.view.split_horizontal(2)?;
+        l.place(&mut self.a, vp, parts[0])?;
+        l.place(&mut self.b, vp, parts[1])?;
         Ok(())
     }
 

--- a/canopy/src/viewport.rs
+++ b/canopy/src/viewport.rs
@@ -256,7 +256,7 @@ impl ViewPort {
             let region = view_in_parent.rebase_rect(&overlap).ok()?;
             // Now, to calculate the screen offset, we take the relative position in the parent's projection, then add
             // that to the screen offset.
-            let p = parent_projection.region.rebase_point(region.tl).ok()?;
+            let p = parent_projection.region.rebase_point(overlap.tl).ok()?;
             Some(Projection::new(
                 region,
                 (
@@ -315,7 +315,7 @@ mod tests {
         let v = ViewPort::new((30, 30), (10, 10, 10, 10), (5, 5))?;
         assert_eq!(
             v.projection(Projection::new((10, 10, 10, 10), (0, 0))),
-            Some(Projection::new((0, 0, 30, 30), (10, 10))),
+            Some(Projection::new((5, 5, 5, 5), (0, 0))),
         );
 
         Ok(())

--- a/canopy/src/widgets/editor/editor.rs
+++ b/canopy/src/widgets/editor/editor.rs
@@ -115,7 +115,8 @@ impl Node for Editor {
     }
 
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
-        l.place(&mut self.view, sz.rect())?;
+        let vp = self.vp();
+        l.place(&mut self.view, vp, sz.rect())?;
         let vp = self.view.vp();
         l.wrap(self, vp)?;
         Ok(())

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -280,18 +280,20 @@ where
             h += i.virt.h
         }
         l.size(self, Expanse { w, h }, r)?;
+        let vp = self.vp();
+        for itm in &mut self.items {
+            if let Some(child_vp) = vp.map(itm.virt)? {
+                *itm.itm.__vp_mut() = child_vp;
+                itm.itm.unhide();
+            } else {
+                itm.itm.hide();
+                itm.itm.__vp_mut().view = Rect::default();
+            }
+        }
         Ok(())
     }
 
     fn render(&mut self, _c: &dyn Context, _: &mut Render) -> Result<()> {
-        let vp = self.vp();
-        for itm in &mut self.items {
-            if let Some(_) = vp.map(itm.virt)? {
-                itm.itm.unhide();
-            } else {
-                itm.itm.hide();
-            }
-        }
         Ok(())
     }
 }

--- a/canopy/src/widgets/panes.rs
+++ b/canopy/src/widgets/panes.rs
@@ -101,10 +101,11 @@ impl<N: Node> Node for Panes<N> {
     }
 
     fn layout(&mut self, l: &Layout, _: Expanse) -> Result<()> {
-        let lst = self.vp().screen_rect().split_panes(&self.shape())?;
+        let vp = self.vp();
+        let lst = vp.screen_rect().split_panes(&self.shape())?;
         for (ci, col) in self.children.iter_mut().enumerate() {
             for (ri, row) in col.iter_mut().enumerate() {
-                l.place(row, lst[ci][ri])?;
+                l.place(row, vp, lst[ci][ri])?;
             }
         }
         Ok(())

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -152,13 +152,14 @@ impl Todo {
 impl Node for Todo {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> canopy::Result<()> {
         l.fill(self, sz)?;
-        let (a, b) = self.vp().view.carve_vend(1);
-        l.place(&mut self.statusbar, b)?;
-        l.place(&mut self.content, a)?;
+        let vp = self.vp();
+        let (a, b) = vp.view.carve_vend(1);
+        l.place(&mut self.statusbar, vp, b)?;
+        l.place(&mut self.content, vp, a)?;
 
         let a = self.vp().screen_rect();
         if let Some(add) = &mut self.adder {
-            l.place(add, Rect::new(a.tl.x + 2, a.tl.y + a.h / 2, a.w - 4, 3))?;
+            l.place(add, vp, Rect::new(a.tl.x + 2, a.tl.y + a.h / 2, a.w - 4, 3))?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- correct leaf layout so fixed-size nodes size properly
- offset child placement relative to parent viewports
- wire up placement calls with parent viewports
- update list widget layout to clamp item viewports

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6858bee4c78483339b83947fc4d18ac6