### PR TITLE
Fix layout calculations in Panes widget

### DIFF
--- a/canopy/src/widgets/panes.rs
+++ b/canopy/src/widgets/panes.rs
@@ -100,9 +100,10 @@ impl<N: Node> Node for Panes<N> {
         Ok(())
     }
 
-    fn layout(&mut self, l: &Layout, _: Expanse) -> Result<()> {
+    fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+        l.fill(self, sz)?;
         let vp = self.vp();
-        let lst = vp.screen_rect().split_panes(&self.shape())?;
+        let lst = vp.canvas.rect().split_panes(&self.shape())?;
         for (ci, col) in self.children.iter_mut().enumerate() {
             for (ri, row) in col.iter_mut().enumerate() {
                 l.place(row, vp, lst[ci][ri])?;
@@ -116,6 +117,12 @@ impl<N: Node> Node for Panes<N> {
 mod tests {
     use super::*;
     use crate::tutils::*;
+
+    fn split(len: u16, n: u16) -> Vec<u16> {
+        let w = len / n;
+        let rem = len % n;
+        (0..n).map(|i| if i < rem { w + 1 } else { w }).collect()
+    }
 
     #[test]
     fn tlayout() -> Result<()> {
@@ -145,6 +152,107 @@ mod tests {
 
         c.set_focus(&mut p.children[1][0].a);
         assert_eq!(p.focus_coords(&c), Some((1, 0)));
+        Ok(())
+    }
+
+    #[derive(StatefulNode)]
+    struct Root {
+        state: NodeState,
+        panes: Panes<TFixed>,
+    }
+
+    #[derive_commands]
+    impl Root {
+        fn new() -> Self {
+            Root {
+                state: NodeState::default(),
+                panes: Panes::new(TFixed::new(1, 1)),
+            }
+        }
+    }
+
+    impl Node for Root {
+        fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+            f(&mut self.panes)
+        }
+
+        fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+            l.fill(self, sz)?;
+            let vp = self.vp();
+            let parts = vp.view.split_horizontal(2)?;
+            l.place(&mut self.panes, vp, parts[1])?;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn tlayout_offset() -> Result<()> {
+        let mut c = Canopy::new();
+        let mut root = Root::new();
+        let l = Layout {};
+
+        c.set_root_size(Expanse::new(20, 10), &mut root)?;
+        root.panes.insert_col(&mut c, TFixed::new(1, 1))?;
+        root.layout(&l, Expanse::new(20, 10))?;
+
+        assert_eq!(root.panes.children.len(), 2);
+        assert_eq!(root.panes.children[0][0].vp().position.x, 10);
+        assert_eq!(root.panes.children[1][0].vp().position.x, 15);
+        Ok(())
+    }
+
+    fn check_tiles(p: &Panes<TFixed>) -> Result<()> {
+        let vp = p.vp();
+        let shape = p.shape();
+        let col_widths = split(vp.canvas.w, shape.len() as u16);
+        let mut x = vp.position.x;
+        let mut expect_pos: Vec<(u16, u16)> = vec![];
+        for (ci, rows) in shape.iter().enumerate() {
+            let heights = split(vp.canvas.h, *rows);
+            let mut y = vp.position.y;
+            for h in heights {
+                expect_pos.push((x, y));
+                y += h;
+            }
+            x += col_widths[ci as usize];
+        }
+        expect_pos.sort();
+
+        let mut actual_pos: Vec<(u16, u16)> = vec![];
+        for col in &p.children {
+            for ch in col {
+                let r = ch.vp().screen_rect();
+                actual_pos.push((r.tl.x, r.tl.y));
+            }
+        }
+        actual_pos.sort();
+
+        assert_eq!(actual_pos, expect_pos);
+        Ok(())
+    }
+
+    #[test]
+    fn tlayout_tiling_and_scroll() -> Result<()> {
+        let mut c = Canopy::new();
+        let mut p: Panes<TFixed> = Panes::new(TFixed::new(1, 1));
+        let l = Layout {};
+
+        p.insert_col(&mut c, TFixed::new(1, 1))?;
+        p.insert_col(&mut c, TFixed::new(1, 1))?;
+        c.set_focus(&mut p.children[0][0]);
+        p.insert_row(&mut c, TFixed::new(1, 1));
+        p.layout(&l, Expanse::new(9, 6))?;
+        // verify positions without scrolling
+        check_tiles(&p)?;
+        
+        // Scroll the container and insert more splits
+        for _ in 0..2 {
+            p.__vp_mut().scroll_right();
+        }
+        p.insert_col(&mut c, TFixed::new(1, 1))?;
+        p.insert_row(&mut c, TFixed::new(1, 1));
+        p.layout(&l, Expanse::new(9, 6))?;
+        check_tiles(&p)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- correct pane placement by working with the viewport canvas
- add helper splitter and regression tests to verify tiling even when scrolled

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_6858fb15310483338c5a7a82b65d610c