### PR TITLE
Fix layout calculations in Panes widget

### DIFF
--- a/canopy/src/layout.rs
+++ b/canopy/src/layout.rs
@@ -43,10 +43,10 @@ impl Layout {
 
     /// Place a child in a given sub-rectangle of a parent's view.
     pub fn place(&self, child: &mut dyn Node, parent_vp: ViewPort, loc: Rect) -> Result<()> {
-        child.layout(self, loc.expanse())?;
         child.__vp_mut().position = parent_vp
             .position
             .scroll(loc.tl.x as i16, loc.tl.y as i16);
+        child.layout(self, loc.expanse())?;
         Ok(())
     }
 

--- a/canopy/src/tutils/mod.rs
+++ b/canopy/src/tutils/mod.rs
@@ -120,6 +120,21 @@ mod tests {
         fn new(horizontal: bool) -> Self {
             Block { state: NodeState::default(), children: vec![], horizontal }
         }
+
+        /// Split this block into two children, toggling orientation like the
+        /// `focusgym` example.
+        fn split(&mut self) {
+            self.children = vec![Block::new(!self.horizontal), Block::new(!self.horizontal)];
+        }
+
+        /// Split using a `Context` to replicate the behaviour of the
+        /// `focusgym` example, which taints the tree and moves focus to the
+        /// new pane.
+        fn split_ctx(&mut self, c: &mut dyn Context) {
+            self.split();
+            c.taint_tree(self);
+            c.focus_next(self);
+        }
     }
 
     impl Node for Block {
@@ -171,6 +186,98 @@ mod tests {
         canopy.set_root_size(Expanse::new(20, 10), &mut root)?;
         canopy.render(&mut tr, &mut root)?;
         assert!(!tr.buf_empty());
+        Ok(())
+    }
+
+    fn gather_leaves<'a>(b: &'a Block, out: &mut Vec<&'a Block>) {
+        if b.children.is_empty() {
+            out.push(b);
+        } else {
+            for c in &b.children {
+                gather_leaves(c, out);
+            }
+        }
+    }
+
+    fn expected_rects(b: &Block, area: Rect) -> Result<Vec<Rect>> {
+        if b.children.is_empty() {
+            return Ok(vec![area]);
+        }
+        let vps = if b.horizontal {
+            area.split_horizontal(b.children.len() as u16)?
+        } else {
+            area.split_vertical(b.children.len() as u16)?
+        };
+        let mut ret = Vec::new();
+        for (child, rect) in b.children.iter().zip(vps.into_iter()) {
+            ret.extend(expected_rects(child, rect)?);
+        }
+        Ok(ret)
+    }
+
+    #[test]
+    fn focusgym_layout() -> Result<()> {
+        let mut canopy = Canopy::new();
+        let mut root = Block {
+            state: NodeState::default(),
+            children: vec![Block::new(false), Block::new(false)],
+            horizontal: true,
+        };
+        let l = Layout {};
+
+        canopy.set_root_size(Expanse::new(20, 10), &mut root)?;
+
+        // Split the right-hand block, then split its bottom block
+        root.children[1].split();
+        root.children[1].children[1].split();
+
+        root.layout(&l, Expanse::new(20, 10))?;
+
+        let mut leaves = Vec::new();
+        gather_leaves(&root, &mut leaves);
+        let expect = expected_rects(&root, root.vp().screen_rect())?;
+
+        let got: Vec<Rect> = leaves.iter().map(|b| b.vp().screen_rect()).collect();
+        assert_eq!(got, expect);
+
+        Ok(())
+    }
+
+    #[test]
+    fn focusgym_split_right_render() -> Result<()> {
+        let (_, mut tr) = TestRender::create();
+        let mut canopy = Canopy::new();
+        let mut root = Block {
+            state: NodeState::default(),
+            children: vec![Block::new(false), Block::new(false)],
+            horizontal: true,
+        };
+        let l = Layout {};
+
+        canopy.set_root_size(Expanse::new(20, 10), &mut root)?;
+        canopy.set_focus(&mut root.children[1]);
+        root.children[1].split_ctx(&mut canopy);
+
+        root.layout(&l, Expanse::new(20, 10))?;
+
+        let mut leaves = Vec::new();
+        gather_leaves(&root, &mut leaves);
+        let expect = expected_rects(&root, root.vp().screen_rect())?;
+        let got: Vec<Rect> = leaves.iter().map(|b| b.vp().screen_rect()).collect();
+        assert_eq!(got, expect);
+
+        canopy.render(&mut tr, &mut root)?;
+        assert!(!tr.buf_empty());
+
+        // Ensure the leaves exactly cover the root without overlap
+        use crate::geom::Coverage;
+        let root_rect = root.vp().screen_rect();
+        let mut cov = Coverage::new(root_rect.expanse());
+        for r in &got {
+            cov.add(r.shift(-(root_rect.tl.x as i16), -(root_rect.tl.y as i16)));
+        }
+        assert!(cov.uncovered().is_empty());
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- correct child placement by updating `Layout::place`
- implement `Block::split` helper for tests
- add `focusgym_layout` regression test following example split pattern
- add context-aware focusgym test verifying rendered placement

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6858fb15310483338c5a7a82b65d610c