### PR TITLE
Fix layout calculations in Panes widget

### DIFF
--- a/canopy/src/layout.rs
+++ b/canopy/src/layout.rs
@@ -43,10 +43,10 @@ impl Layout {
 
     /// Place a child in a given sub-rectangle of a parent's view.
     pub fn place(&self, child: &mut dyn Node, parent_vp: ViewPort, loc: Rect) -> Result<()> {
-        child.layout(self, loc.expanse())?;
         child.__vp_mut().position = parent_vp
             .position
             .scroll(loc.tl.x as i16, loc.tl.y as i16);
+        child.layout(self, loc.expanse())?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- correct child placement by updating `Layout::place`
- implement `Block::split` helper for tests
- add `focusgym_layout` regression test following example split pattern
- add regression test splitting the right-hand top pane

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6858fb15310483338c5a7a82b65d610c