### PR TITLE
Fix layout calculations in Panes widget

### DIFF
--- a/canopy/src/canopy.rs
+++ b/canopy/src/canopy.rs
@@ -602,8 +602,7 @@ impl Canopy {
             if n.state().render_gen == 0 {
                 n.state_mut().render_gen = self.render_gen;
             }
-            let proj = n.vp().position;
-            n.children(&mut |x| self.render_traversal(r, styl, x, base + proj))?;
+            n.children(&mut |x| self.render_traversal(r, styl, x, base))?;
             styl.pop();
         }
         Ok(())
@@ -626,13 +625,8 @@ impl Canopy {
                 Walk::Continue
             })
         })?;
-        if let Some((nid, vp, c)) = cn {
-            let mut base = Point { x: 0, y: 0 };
-            walk_to_root(root, &nid, &mut |x| {
-                base = base + x.vp().position;
-                Ok(())
-            })?;
-            show_cursor(r, &self.style, styl, vp, "cursor", c + base)?;
+        if let Some((_nid, vp, c)) = cn {
+            show_cursor(r, &self.style, styl, vp, "cursor", c + vp.position)?;
         }
 
         Ok(())

--- a/canopy/src/error.rs
+++ b/canopy/src/error.rs
@@ -4,6 +4,8 @@ use std::{
 };
 
 use crate::backend::test::TestBuf;
+#[cfg(test)]
+use crate::backend::test::CanvasBuf;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -55,6 +57,13 @@ impl From<mpsc::RecvError> for Error {
 
 impl From<PoisonError<MutexGuard<'_, TestBuf>>> for Error {
     fn from(e: PoisonError<MutexGuard<'_, TestBuf>>) -> Self {
+        Error::RunLoop(e.to_string())
+    }
+}
+
+#[cfg(test)]
+impl From<PoisonError<MutexGuard<'_, CanvasBuf>>> for Error {
+    fn from(e: PoisonError<MutexGuard<'_, CanvasBuf>>) -> Self {
         Error::RunLoop(e.to_string())
     }
 }

--- a/canopy/src/layout.rs
+++ b/canopy/src/layout.rs
@@ -43,10 +43,10 @@ impl Layout {
 
     /// Place a child in a given sub-rectangle of a parent's view.
     pub fn place(&self, child: &mut dyn Node, parent_vp: ViewPort, loc: Rect) -> Result<()> {
-        child.layout(self, loc.expanse())?;
         child.__vp_mut().position = parent_vp
             .position
             .scroll(loc.tl.x as i16, loc.tl.y as i16);
+        child.layout(self, loc.expanse())?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- correct child placement by updating `Layout::place`
- implement `Block::split` helper for tests
- add `focusgym_layout` regression test following example split pattern
- add context-aware focusgym test verifying rendered placement
- extend nesting tests to cover deeper splits
- add `CanvasRender` for precise render verification
- update `render_traversal` and cursor calculations to use absolute positions
- add regression test validating rendered output with nested splits

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6858fb15310483338c5a7a82b65d610c