### PR TITLE
Render after events

### DIFF
--- a/canopy/src/backend/crossterm.rs
+++ b/canopy/src/backend/crossterm.rs
@@ -402,15 +402,16 @@ where
     cnpy.set_root_size(Expanse::new(size.0, size.1), &mut root)?;
     cnpy.start_poller(cnpy.event_tx.clone());
 
-    let mut tainted = true;
+    cnpy.render(&mut be, &mut root)?;
+    translate_result(be.flush())?;
+
     loop {
-        if tainted {
-            cnpy.render(&mut be, &mut root)?;
-            translate_result(be.flush())?;
-        }
         cnpy.event(&mut root, events.next()?)?;
 
-        tainted = cnpy.taint;
-        cnpy.taint = false;
+        if cnpy.taint || cnpy.focus_changed() {
+            cnpy.render(&mut be, &mut root)?;
+            translate_result(be.flush())?;
+            cnpy.taint = false;
+        }
     }
 }

--- a/canopy/src/tutils/mod.rs
+++ b/canopy/src/tutils/mod.rs
@@ -428,4 +428,25 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn render_on_focus_change() -> Result<()> {
+        let (_, mut tr) = TestRender::create();
+        let mut canopy = Canopy::new();
+        let mut root = Block {
+            state: NodeState::default(),
+            children: vec![Block::new(false), Block::new(false)],
+            horizontal: true,
+        };
+
+        canopy.set_root_size(Expanse::new(20, 10), &mut root)?;
+        canopy.render(&mut tr, &mut root)?;
+        tr.text.lock()?.text.clear();
+
+        canopy.focus_next(&mut root);
+        canopy.render(&mut tr, &mut root)?;
+        assert!(!tr.buf_empty());
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- re-order the crossterm run loop so events are handled before rendering
- add unit test verifying render on focus change

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6859190a8e088333bf4989942fd1cf32