### PR TITLE
Fix list rendering coverage

### DIFF
--- a/canopy/src/widgets/frame.rs
+++ b/canopy/src/widgets/frame.rs
@@ -163,7 +163,7 @@ where
             .vp()
             .view
             .inner(1)
-            .sub(&self.child.vp().canvas.rect().shift(1, 1))
+            .sub(&self.child.vp().screen_rect())
         {
             rndr.fill(style, r, ' ')?;
         }

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -293,7 +293,8 @@ where
         Ok(())
     }
 
-    fn render(&mut self, _c: &dyn Context, _: &mut Render) -> Result<()> {
+    fn render(&mut self, _c: &dyn Context, rndr: &mut Render) -> Result<()> {
+        rndr.fill("", self.vp().canvas.rect(), ' ')?;
         Ok(())
     }
 }
@@ -301,11 +302,20 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
     use crate::{
         backend::test::TestRender,
         tutils::{DummyContext, TFixed},
         Context,
+        widgets::Text,
+        widgets::frame,
+        cursor,
+        geom::Point,
+        render::RenderBackend,
+        style::Style,
     };
+
+    impl ListItem for Text {}
 
     pub fn views(lst: &mut List<TFixed>) -> Vec<Rect> {
         let mut v = vec![];
@@ -451,4 +461,584 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn frame_repaints_on_scroll() -> Result<()> {
+        use crate::backend::test::CanvasRender;
+        use crate::widgets::{frame, text::Text};
+
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            list: frame::Frame<List<Text>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    list: frame::Frame::new(List::new(vec![
+                        Text::new("AAAA").with_fixed_width(4),
+                        Text::new("BBBB").with_fixed_width(4),
+                        Text::new("CCCC").with_fixed_width(4),
+                        Text::new("DDDD").with_fixed_width(4),
+                    ])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.list)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.list, vp, vp.view)?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(10, 5);
+        let (buf, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+        let first = buf.lock().unwrap().cells.clone();
+
+        assert_eq!(first[1][1], 'A');
+        assert_eq!(first[2][1], 'B');
+
+        let corner = first[0][0];
+
+        canopy.scroll_down(&mut root.list.child);
+        canopy.taint_tree(&mut root);
+        canopy.render(&mut cr, &mut root)?;
+        let second = buf.lock().unwrap().cells.clone();
+
+        assert_eq!(second[1][1], 'B');
+        assert_eq!(second[2][1], 'C');
+        assert_eq!(second[0][0], corner);
+
+        canopy.scroll_up(&mut root.list.child);
+        canopy.taint_tree(&mut root);
+        canopy.render(&mut cr, &mut root)?;
+        let third = buf.lock().unwrap().cells.clone();
+
+        assert_eq!(third[1][1], 'A');
+        assert_eq!(third[2][1], 'B');
+        assert_eq!(third[0][0], corner);
+
+        Ok(())
+    }
+
+
+    struct PaintTracker {
+        painted: Arc<Mutex<Vec<Vec<bool>>>>,
+        size: Expanse,
+    }
+
+    impl PaintTracker {
+        fn create(size: Expanse) -> (Arc<Mutex<Vec<Vec<bool>>>>, Self) {
+            let buf = Arc::new(Mutex::new(vec![vec![false; size.w as usize]; size.h as usize]));
+            (buf.clone(), PaintTracker { painted: buf, size })
+        }
+    }
+
+    impl RenderBackend for PaintTracker {
+        fn reset(&mut self) -> Result<()> {
+            let mut buf = self.painted.lock().unwrap();
+            for row in &mut *buf {
+                for c in row.iter_mut() {
+                    *c = false;
+                }
+            }
+            Ok(())
+        }
+
+        fn flush(&mut self) -> Result<()> { Ok(()) }
+        fn show_cursor(&mut self, _c: cursor::Cursor) -> Result<()> { Ok(()) }
+        fn hide_cursor(&mut self) -> Result<()> { Ok(()) }
+        fn style(&mut self, _s: Style) -> Result<()> { Ok(()) }
+
+        fn text(&mut self, loc: Point, txt: &str) -> Result<()> {
+            let mut buf = self.painted.lock().unwrap();
+            for (i, _ch) in txt.chars().enumerate() {
+                let x = loc.x as usize + i;
+                let y = loc.y as usize;
+                if x < self.size.w as usize && y < self.size.h as usize {
+                    buf[y][x] = true;
+                }
+            }
+            Ok(())
+        }
+
+        fn exit(&mut self, _code: i32) -> ! { unreachable!() }
+    }
+
+    #[test]
+    fn list_items_within_bounds() -> Result<()> {
+        const SAMPLE: &str = "aaa bbb ccc\nddd";
+
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new(w: u16) -> Self {
+                Block { state: NodeState::default(), text: Text::new(SAMPLE).with_fixed_width(w) }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, s: Expanse) -> Result<()> {
+                l.fill(self, s)?;
+                let vp = self.vp();
+                l.place(&mut self.text, vp, Rect::new(0, 0, s.w, s.h))?;
+                let vp = self.text.vp();
+                let sz = Expanse { w: vp.canvas.w, h: vp.canvas.h };
+                l.size(self, sz, sz)?;
+                Ok(())
+            }
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            frame: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    frame: frame::Frame::new(List::new(vec![
+                        Block::new(4),
+                        Block::new(7),
+                        Block::new(5),
+                    ])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.frame)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.frame, vp, vp.view)?;
+                Ok(())
+            }
+        }
+
+        let mut canopy = Canopy::new();
+        let size = Expanse::new(20, 20);
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+
+        let list_rect = root.frame.child.vp().view;
+        let mut rects = Vec::new();
+        root.frame.child.children(&mut |n| {
+            if !n.is_hidden() {
+                rects.push(n.vp().view);
+            }
+            Ok(())
+        })?;
+        for r in &rects {
+            assert!(list_rect.contains_rect(r));
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn canvas_background_painted() -> Result<()> {
+        const SAMPLE: &str = "aaa bbb ccc\nddd";
+
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new(w: u16) -> Self {
+                Block { state: NodeState::default(), text: Text::new(SAMPLE).with_fixed_width(w) }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, s: Expanse) -> Result<()> {
+                l.fill(self, s)?;
+                let vp = self.vp();
+                l.place(&mut self.text, vp, Rect::new(0, 0, s.w, s.h))?;
+                let vp = self.text.vp();
+                let sz = Expanse { w: vp.canvas.w, h: vp.canvas.h };
+                l.size(self, sz, sz)?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            frame: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    frame: frame::Frame::new(List::new(vec![
+                        Block::new(4),
+                        Block::new(7),
+                        Block::new(5),
+                    ])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.frame)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.frame, vp, vp.view)?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(20, 8);
+        let (buf, mut pr) = PaintTracker::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut pr, &mut root)?;
+
+        let painted = buf.lock().unwrap();
+        let rect = root.vp().screen_rect();
+        assert!(painted[0][0]);
+        assert!(painted[(rect.h - 1) as usize][(rect.w - 1) as usize]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn canvas_painted_after_scroll() -> Result<()> {
+        const SAMPLE: &str = "aaa bbb ccc\nddd";
+
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new(w: u16) -> Self {
+                Block { state: NodeState::default(), text: Text::new(SAMPLE).with_fixed_width(w) }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, s: Expanse) -> Result<()> {
+                l.fill(self, s)?;
+                let vp = self.vp();
+                l.place(&mut self.text, vp, Rect::new(0, 0, s.w, s.h))?;
+                let vp = self.text.vp();
+                let sz = Expanse { w: vp.canvas.w, h: vp.canvas.h };
+                l.size(self, sz, sz)?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            frame: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    frame: frame::Frame::new(List::new(vec![
+                        Block::new(4),
+                        Block::new(7),
+                        Block::new(5),
+                    ])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.frame)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.frame, vp, vp.view)?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(20, 8);
+        let (buf, mut pr) = PaintTracker::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut pr, &mut root)?;
+        {
+            let painted = buf.lock().unwrap();
+            for row in painted.iter() {
+                assert!(row.iter().all(|&c| c));
+            }
+        }
+
+        canopy.scroll_down(&mut root.frame.child);
+        canopy.taint_tree(&mut root);
+        canopy.render(&mut pr, &mut root)?;
+        {
+            let painted = buf.lock().unwrap();
+            for row in painted.iter() {
+                assert!(row.iter().all(|&c| c));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn rects<N: Node + ListItem>(list: &mut List<N>) -> Vec<Rect> {
+        let mut r = vec![];
+        list.children(&mut |n| {
+            if !n.is_hidden() {
+                r.push(n.vp().screen_rect());
+            }
+            Ok(())
+        })
+        .unwrap();
+        r
+    }
+
+    fn assert_non_overlapping(rects: &[Rect], bounds: Rect) {
+        let mut prev: Option<Rect> = None;
+        for r in rects {
+            assert!(bounds.contains_rect(r));
+            if let Some(p) = prev {
+                assert!(p.tl.y + p.h <= r.tl.y);
+            }
+            prev = Some(*r);
+        }
+    }
+
+    #[test]
+    fn list_items_do_not_overlap_initial() -> Result<()> {
+        use crate::backend::test::CanvasRender;
+        const SAMPLE: &str = "aaa bbb ccc\nddd";
+
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new(w: u16) -> Self {
+                Block { state: NodeState::default(), text: Text::new(SAMPLE).with_fixed_width(w) }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, s: Expanse) -> Result<()> {
+                l.fill(self, s)?;
+                let vp = self.vp();
+                l.place(&mut self.text, vp, Rect::new(0, 0, s.w, s.h))?;
+                let vp = self.text.vp();
+                let sz = Expanse { w: vp.canvas.w, h: vp.canvas.h };
+                l.size(self, sz, sz)?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            frame: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    frame: frame::Frame::new(List::new(vec![
+                        Block::new(4),
+                        Block::new(7),
+                        Block::new(5),
+                    ])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.frame)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.frame, vp, vp.view)?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(20, 8);
+        let (_, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+
+        let rects = rects(&mut root.frame.child);
+        assert_non_overlapping(&rects, root.frame.child.vp().screen_rect());
+
+        Ok(())
+    }
+
+    #[test]
+    fn list_items_do_not_overlap_after_scroll() -> Result<()> {
+        use crate::backend::test::CanvasRender;
+        const SAMPLE: &str = "aaa bbb ccc\nddd";
+
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new(w: u16) -> Self {
+                Block { state: NodeState::default(), text: Text::new(SAMPLE).with_fixed_width(w) }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, s: Expanse) -> Result<()> {
+                l.fill(self, s)?;
+                let vp = self.vp();
+                l.place(&mut self.text, vp, Rect::new(0, 0, s.w, s.h))?;
+                let vp = self.text.vp();
+                let sz = Expanse { w: vp.canvas.w, h: vp.canvas.h };
+                l.size(self, sz, sz)?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            frame: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    frame: frame::Frame::new(List::new(vec![
+                        Block::new(4),
+                        Block::new(7),
+                        Block::new(5),
+                    ])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.frame)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.frame, vp, vp.view)?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(20, 8);
+        let (_, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+
+        canopy.scroll_down(&mut root.frame.child);
+        canopy.taint_tree(&mut root);
+        canopy.render(&mut cr, &mut root)?;
+
+        let rects = rects(&mut root.frame.child);
+        assert_non_overlapping(&rects, root.frame.child.vp().screen_rect());
+
+        Ok(())
+    }
+
 }


### PR DESCRIPTION
## Summary
- ensure frame calculates empty space using child's screen rect
- fill list background during render so gaps are repainted
- add tests verifying list items don't overlap on render or after scrolling

## Testing
- `cargo test --quiet canvas_painted_after_scroll -- --nocapture`
- `cargo test --quiet list_items_do_not_overlap_initial -- --nocapture`
- `cargo test --quiet list_items_do_not_overlap_after_scroll -- --nocapture`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68593059e1348333aea15fe4ef779d4a