### PR TITLE
Fix list rendering coverage

### DIFF
--- a/canopy/src/geom/rect.rs
+++ b/canopy/src/geom/rect.rs
@@ -419,7 +419,7 @@ impl Rect {
                         x: isec.tl.x,
                         y: isec.tl.y + isec.h,
                     },
-                    h: (self.tl.x + self.h).saturating_sub(isec.tl.y + isec.h),
+                    h: (self.tl.y + self.h).saturating_sub(isec.tl.y + isec.h),
                     w: isec.w,
                 },
             ];

--- a/canopy/src/widgets/frame.rs
+++ b/canopy/src/widgets/frame.rs
@@ -163,7 +163,7 @@ where
             .vp()
             .view
             .inner(1)
-            .sub(&self.child.vp().canvas.rect().shift(1, 1))
+            .sub(&self.vp().unproject(self.child.vp().screen_rect())?)
         {
             rndr.fill(style, r, ' ')?;
         }


### PR DESCRIPTION
## Summary
- ensure frame calculates empty space using child's screen rect
- fill list background during render so gaps are repainted
- simplify tests and add scroll boundary check

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68593059e1348333aea15fe4ef779d4a