### PR TITLE
Fix initial render of listgym example

### DIFF
--- a/canopy/examples/listgym.rs
+++ b/canopy/examples/listgym.rs
@@ -129,11 +129,15 @@ impl ListGym {
 
 impl Node for ListGym {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+        // First fill our viewport so that child placement calculations use the
+        // correct geometry. Without this the initial layout runs with a zero
+        // sized viewport, causing the list to appear empty until a subsequent
+        // event triggers another layout.
+        l.fill(self, sz)?;
         let vp = self.vp();
-        let (a, b) = vp.screen_rect().carve_vend(1);
+        let (a, b) = vp.view.carve_vend(1);
         l.place(&mut self.content, vp, a)?;
         l.place(&mut self.statusbar, vp, b)?;
-        l.fill(self, sz)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- ensure listgym layout initializes viewport before placing children
- keep frame from rendering overlap by using view rect

## Testing
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_6859d81d0e148333b62f0c79b1239790