### PR TITLE
Add viewport-based check for list scrolling

### DIFF
--- a/canopy/src/widgets/text.rs
+++ b/canopy/src/widgets/text.rs
@@ -1,6 +1,6 @@
 use crate as canopy;
 use crate::{
-    geom::Expanse,
+    geom::{Expanse, Line},
     state::{NodeState, StatefulNode},
     *,
 };
@@ -95,14 +95,13 @@ impl Node for Text {
     }
 
     fn render(&mut self, _c: &dyn Context, rndr: &mut Render) -> Result<()> {
-        let vo = self.vp().view;
+        let vp = self.vp();
+        let vo = vp.view;
         if let Some(lines) = self.lines.as_ref() {
             for i in 0..vo.h {
-                let out = &lines[(vo.tl.y + i) as usize]
-                    .chars()
-                    .skip(vo.tl.x as usize)
-                    .collect::<String>();
-                rndr.text("text", vo.line(i), out)?;
+                let idx = (vo.tl.y + i) as usize;
+                let line = Line::new(0, vo.tl.y + i, self.current_size.w);
+                rndr.text("text", line, &lines[idx])?;
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary
- unignore list scrolling tests
- update horizontal scroll test to verify viewport movement
- render text lines using full line rectangles

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6859e387904083339321c309c6f90c17