### PR TITLE
Fix list scrolling and keep offsets in Frame

### DIFF
--- a/canopy/src/layout.rs
+++ b/canopy/src/layout.rs
@@ -19,6 +19,7 @@ impl Layout {
     /// Frame a single child node. First, we calculate the inner size after subtracting the frame. We then fit the child
     /// into this inner size, and project it appropriately in the parent view.
     pub fn frame(&self, child: &mut dyn Node, sz: Expanse, border: u16) -> Result<Frame> {
+        let vp = child.vp();
         child.__vp_mut().position = crate::geom::Point {
             x: border,
             y: border,
@@ -30,6 +31,11 @@ impl Layout {
                 h: sz.h.saturating_sub(border * 2),
             },
         )?;
+        fn set_offset(n: &mut dyn Node, x: u16, y: u16) -> Result<()> {
+            n.__vp_mut().scroll_to(x, y);
+            n.children(&mut |c| set_offset(c, x, y))
+        }
+        set_offset(child, vp.view.tl.x, vp.view.tl.y)?;
         Ok(crate::geom::Frame::new(sz.rect(), border))
     }
 

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -857,4 +857,186 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn list_does_not_overdraw_frame_bottom() -> Result<()> {
+        const SAMPLE: &str = "line1\nline2";
+
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new() -> Self {
+                Block {
+                    state: NodeState::default(),
+                    text: Text::new(SAMPLE).with_fixed_width(4),
+                }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.text, vp, Rect::new(0, 0, sz.w, sz.h))?;
+                let vp = self.text.vp();
+                let sz = Expanse {
+                    w: vp.canvas.w,
+                    h: vp.canvas.h,
+                };
+                l.size(self, sz, sz)?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            frame: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    frame: frame::Frame::new(List::new(vec![
+                        Block::new(),
+                        Block::new(),
+                        Block::new(),
+                        Block::new(),
+                    ])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.frame)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.frame, vp, vp.view)?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(10, 6);
+        let (buf, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+        let bottom = buf.lock().unwrap().cells[(size.h - 1) as usize].clone();
+
+        canopy.scroll_down(&mut root.frame.child);
+        canopy.taint_tree(&mut root);
+        canopy.render(&mut cr, &mut root)?;
+        let bottom_after = buf.lock().unwrap().cells[(size.h - 1) as usize].clone();
+
+        assert_eq!(bottom, bottom_after);
+
+        Ok(())
+    }
+
+    #[test]
+    fn list_horizontal_scroll_moves_view() -> Result<()> {
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new() -> Self {
+                Block {
+                    state: NodeState::default(),
+                    text: Text::new("ABCDE").with_fixed_width(30),
+                }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.text, vp, Rect::new(0, 0, sz.w, sz.h))?;
+                let vp = self.text.vp();
+                let sz = Expanse {
+                    w: vp.canvas.w,
+                    h: vp.canvas.h,
+                };
+                l.size(self, sz, sz)?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            frame: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    frame: frame::Frame::new(List::new(vec![Block::new(), Block::new()])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.frame)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.frame, vp, vp.view)?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(10, 4);
+        let (buf, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+        let before = buf.lock().unwrap().cells.clone();
+
+        canopy.scroll_right(&mut root.frame.child);
+        canopy.taint_tree(&mut root);
+        canopy.render(&mut cr, &mut root)?;
+        let after = buf.lock().unwrap().cells.clone();
+
+        assert_ne!(before[1][1], after[1][1]);
+        assert_ne!(before[2][1], after[2][1]);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- keep scroll offsets for all frame descendants during layout
- ensure horizontally scrolling a framed list moves every item

## Testing
- `cargo test list_horizontal_scroll_moves_view -- --nocapture`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6859e387904083339321c309c6f90c17