### PR TITLE
Enforce ViewPort invariants

### DIFF
--- a/canopy/examples/focusgym.rs
+++ b/canopy/examples/focusgym.rs
@@ -26,7 +26,7 @@ impl Block {
 
     #[command]
     fn add(&mut self, c: &mut dyn Context) {
-        if !self.children.is_empty() && !self.size_limited(self.children[0].vp().view.into()) {
+        if !self.children.is_empty() && !self.size_limited(self.children[0].vp().view().into()) {
             self.children.push(Block::new(!self.horizontal));
             c.taint_tree(self);
         }
@@ -38,7 +38,7 @@ impl Block {
 
     #[command]
     fn split(&mut self, c: &mut dyn Context) -> Result<()> {
-        if !self.size_limited(self.vp().view.into()) {
+        if !self.size_limited(self.vp().view().into()) {
             self.children = vec![Block::new(!self.horizontal), Block::new(!self.horizontal)];
             c.taint_tree(self);
             c.focus_next(self);
@@ -59,9 +59,9 @@ impl Node for Block {
         if !self.children.is_empty() {
             let vp = self.vp();
             let vps = if self.horizontal {
-                vp.view.split_horizontal(self.children.len() as u16)?
+                vp.view().split_horizontal(self.children.len() as u16)?
             } else {
-                vp.view.split_vertical(self.children.len() as u16)?
+                vp.view().split_vertical(self.children.len() as u16)?
             };
             for (i, child) in self.children.iter_mut().enumerate() {
                 l.place(child, vp, vps[i])?;
@@ -78,8 +78,8 @@ impl Node for Block {
             } else {
                 "blue"
             };
-            r.fill(bc, vp.view.inner(1), '\u{2588}')?;
-            r.solid_frame("black", Frame::new(vp.view, 1), ' ')?;
+            r.fill(bc, vp.view().inner(1), '\u{2588}')?;
+            r.solid_frame("black", Frame::new(vp.view(), 1), ' ')?;
         }
         Ok(())
     }

--- a/canopy/examples/intervals.rs
+++ b/canopy/examples/intervals.rs
@@ -77,7 +77,7 @@ impl StatusBar {}
 impl Node for StatusBar {
     fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
         r.style.push_layer("statusbar");
-        r.text("statusbar/text", self.vp().view.line(0), "intervals")?;
+        r.text("statusbar/text", self.vp().view().line(0), "intervals")?;
         Ok(())
     }
 }
@@ -113,7 +113,7 @@ impl Node for Intervals {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
         l.fill(self, sz)?;
         let vp = self.vp();
-        let (a, b) = vp.view.carve_vend(1);
+        let (a, b) = vp.view().carve_vend(1);
         l.place(&mut self.statusbar, vp, b)?;
         l.place(&mut self.content, vp, a)?;
         Ok(())

--- a/canopy/examples/listgym.rs
+++ b/canopy/examples/listgym.rs
@@ -53,8 +53,8 @@ impl Node for Block {
 
         let vp = self.child.vp();
         let sz = Expanse {
-            w: vp.canvas.w + 2,
-            h: self.child.vp().canvas.h,
+            w: vp.canvas().w + 2,
+            h: self.child.vp().canvas().h,
         };
         l.size(self, sz, sz)?;
         Ok(())
@@ -63,7 +63,7 @@ impl Node for Block {
     fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
         let vp = self.vp();
         if self.selected {
-            let active = vp.view.carve_hstart(1).0;
+            let active = vp.view().carve_hstart(1).0;
             r.fill("blue", active, '\u{2588}')?;
         }
         r.style.push_layer(&self.color);
@@ -86,7 +86,7 @@ impl StatusBar {}
 impl Node for StatusBar {
     fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
         r.style.push_layer("statusbar");
-        r.text("text", self.vp().view.line(0), "listgym")?;
+        r.text("text", self.vp().view().line(0), "listgym")?;
         Ok(())
     }
 }

--- a/canopy/src/canopy.rs
+++ b/canopy/src/canopy.rs
@@ -595,7 +595,7 @@ impl Canopy {
 
                 // We now have coverage, relative to this node's screen rectange. We
                 // rebase each rect back down to our virtual co-ordinates.
-                let sr = n.vp().view;
+                let sr = n.vp().view();
                 for l in rndr.coverage.uncovered() {
                     rndr.fill("", l.rect().shift(sr.tl.x as i16, sr.tl.y as i16), ' ')?;
                 }
@@ -629,7 +629,7 @@ impl Canopy {
             })
         })?;
         if let Some((_nid, vp, c)) = cn {
-            show_cursor(r, &self.style, styl, vp, "cursor", c + vp.position)?;
+            show_cursor(r, &self.style, styl, vp, "cursor", c + vp.position())?;
         }
 
         Ok(())

--- a/canopy/src/inspector/logs.rs
+++ b/canopy/src/inspector/logs.rs
@@ -45,14 +45,14 @@ impl Node for LogItem {
                 h: target.h,
             },
         )?;
-        let sz = self.child.vp().canvas;
+        let sz = self.child.vp().canvas();
         l.size(self, sz, target)?;
         Ok(())
     }
 
     fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
         let vp = self.vp();
-        let v = vp.view;
+        let v = vp.view();
         let status = Rect::new(v.tl.x, v.tl.y, 1, v.h);
         if self.selected {
             r.fill("blue", status, '\u{2588}')?;

--- a/canopy/src/inspector/view.rs
+++ b/canopy/src/inspector/view.rs
@@ -13,7 +13,7 @@ pub struct View {
 impl Node for View {
     fn layout(&mut self, l: &Layout, _: Expanse) -> Result<()> {
         let vp = self.vp();
-        let (a, b) = vp.view.carve_vstart(1);
+        let (a, b) = vp.view().carve_vstart(1);
         l.place(&mut self.tabs, vp, a)?;
         l.place(&mut self.logs, vp, b)?;
         Ok(())

--- a/canopy/src/layout.rs
+++ b/canopy/src/layout.rs
@@ -11,8 +11,8 @@ impl Layout {
     /// Wrap a single child node, mirroring the child's size and view.
     pub fn wrap(&self, parent: &mut dyn Node, vp: ViewPort) -> Result<()> {
         // Mirror the child's size and view
-        parent.state_mut().set_canvas(vp.canvas);
-        parent.state_mut().set_view(vp.view);
+        parent.state_mut().set_canvas(vp.canvas());
+        parent.state_mut().set_view(vp.view());
         Ok(())
     }
 
@@ -44,7 +44,7 @@ impl Layout {
     pub fn place(&self, child: &mut dyn Node, parent_vp: ViewPort, loc: Rect) -> Result<()> {
         child
             .state_mut()
-            .set_position(parent_vp.position.scroll(loc.tl.x as i16, loc.tl.y as i16));
+            .set_position(parent_vp.position().scroll(loc.tl.x as i16, loc.tl.y as i16));
         child.layout(self, loc.expanse())?;
         child.state_mut().constrain(parent_vp);
         Ok(())
@@ -59,7 +59,7 @@ impl Layout {
     /// adjusts the node's view to place as much of it within the viewport's screen rectangle as possible.
     pub fn fit(&self, n: &mut dyn Node, parent_vp: ViewPort) -> Result<()> {
         n.layout(self, parent_vp.screen_rect().into())?;
-        n.state_mut().set_position(parent_vp.position);
+        n.state_mut().set_position(parent_vp.position());
         n.state_mut().constrain(parent_vp);
         Ok(())
     }
@@ -136,7 +136,7 @@ mod tests {
         let mut child = TFixed::new(2, 2);
         let f = l.frame(&mut child, Expanse::new(1, 1), 1)?;
         assert_eq!(f, Frame::zero());
-        assert_eq!(child.vp().position, Point { x: 1, y: 1 });
+        assert_eq!(child.vp().position(), Point { x: 1, y: 1 });
         Ok(())
     }
 
@@ -162,7 +162,7 @@ mod tests {
         }
 
         fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
-            r.fill("", self.vp().canvas.rect(), 'x')
+            r.fill("", self.vp().canvas().rect(), 'x')
         }
     }
 

--- a/canopy/src/root.rs
+++ b/canopy/src/root.rs
@@ -149,7 +149,7 @@ where
         l.fill(self, sz)?;
         let vp = self.vp();
         if self.inspector_active {
-            let parts = vp.view.split_horizontal(2)?;
+            let parts = vp.view().split_horizontal(2)?;
             l.place(&mut self.inspector, vp, parts[0])?;
             l.place(&mut self.app, vp, parts[1])?;
         } else {

--- a/canopy/src/state.rs
+++ b/canopy/src/state.rs
@@ -128,17 +128,17 @@ pub struct NodeState {
 impl NodeState {
     /// Set the node's position within the parent canvas.
     pub fn set_position(&mut self, p: crate::geom::Point) {
-        self.viewport.position = p;
+        self.viewport.set_position(p);
     }
 
     /// Set the size of the node's canvas.
     pub fn set_canvas(&mut self, sz: crate::geom::Expanse) {
-        self.viewport.canvas = sz;
+        self.viewport.set_canvas(sz);
     }
 
     /// Set the portion of the node that is displayed.
     pub fn set_view(&mut self, view: crate::geom::Rect) {
-        self.viewport.view = view;
+        self.viewport.set_view(view);
     }
 
     /// Constrain this viewport so that its screen rectangle falls within the

--- a/canopy/src/tutils/mod.rs
+++ b/canopy/src/tutils/mod.rs
@@ -147,9 +147,9 @@ mod tests {
             if !self.children.is_empty() {
                 let vp = self.vp();
                 let vps = if self.horizontal {
-                    vp.view.split_horizontal(self.children.len() as u16)?
+                    vp.view().split_horizontal(self.children.len() as u16)?
                 } else {
-                    vp.view.split_vertical(self.children.len() as u16)?
+                    vp.view().split_vertical(self.children.len() as u16)?
                 };
                 for (i, ch) in self.children.iter_mut().enumerate() {
                     l.place(ch, vp, vps[i])?;
@@ -160,7 +160,7 @@ mod tests {
 
         fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
             if self.children.is_empty() {
-                r.fill("blue", self.vp().view, 'x')?;
+                r.fill("blue", self.vp().view(), 'x')?;
             }
             Ok(())
         }
@@ -388,7 +388,7 @@ mod tests {
             fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
                 l.fill(self, sz)?;
                 let vp = self.vp();
-                let parts = vp.view.split_horizontal(2)?;
+                let parts = vp.view().split_horizontal(2)?;
                 l.place(&mut self.child, vp, parts[1])?;
                 Ok(())
             }

--- a/canopy/src/tutils/ttree.rs
+++ b/canopy/src/tutils/ttree.rs
@@ -74,7 +74,7 @@ macro_rules! leaf {
             fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
                 r.text(
                     "any",
-                    self.vp().view.line(0),
+                    self.vp().view().line(0),
                     &format!("<{}>", self.name().clone()),
                 )
             }
@@ -177,7 +177,7 @@ macro_rules! branch {
             fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
                 l.fill(self, sz)?;
                 let vp = self.vp();
-                let parts = vp.view.split_vertical(2)?;
+                let parts = vp.view().split_vertical(2)?;
                 l.place(&mut self.a, vp, parts[0])?;
                 l.place(&mut self.b, vp, parts[1])?;
                 Ok(())
@@ -186,7 +186,7 @@ macro_rules! branch {
             fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
                 r.text(
                     "any",
-                    self.vp().view.line(0),
+                    self.vp().view().line(0),
                     &format!("<{}>", self.name().clone()),
                 )
             }
@@ -261,14 +261,14 @@ impl Node for R {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
         l.fill(self, sz)?;
         let vp = self.vp();
-        let parts = vp.view.split_horizontal(2)?;
+        let parts = vp.view().split_horizontal(2)?;
         l.place(&mut self.a, vp, parts[0])?;
         l.place(&mut self.b, vp, parts[1])?;
         Ok(())
     }
 
     fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
-        r.text("any", self.vp().view.line(0), &format!("<{}>", self.name()))
+        r.text("any", self.vp().view().line(0), &format!("<{}>", self.name()))
     }
 
     fn handle_key(&mut self, _: &mut dyn Context, _: key::Key) -> Result<EventOutcome> {

--- a/canopy/src/viewport.rs
+++ b/canopy/src/viewport.rs
@@ -36,19 +36,19 @@ pub struct ViewPort {
     // within the parent's canvas rectangle.
     //
     // CONSTRAINT: The position must be within the PARENT's canvas rectangle.
-    pub position: Point,
+    position: Point,
 
     /// The portion of this node that is displayed - a sub-rectangle of the canvas. Must only be
     /// changed by the node itself. This is the portion of the node that is drawn to the screen. To
     /// ease widget implementation, when attempting to draw to the screen any draw operations outside the
     /// screen rectangle are ignored.
     // CONSTRAINT: The view rectangle must be fully contained within OUR canvas rectangle.
-    pub view: Rect,
+    view: Rect,
 
     /// The canvas on which children are positioned, and to which rendering occurs. Must only be
     /// changed by the node itself. You can think of this as a rectangle with co-ordinates (0, 0),
     /// which describes the full size of this node and its children.
-    pub canvas: Expanse,
+    canvas: Expanse,
 }
 
 impl ViewPort {
@@ -72,6 +72,46 @@ impl ViewPort {
                 position: position.into(),
             })
         }
+    }
+
+    /// Current position of the viewport within the parent canvas.
+    pub fn position(&self) -> Point {
+        self.position
+    }
+
+    /// Rectangle of the child view within the canvas.
+    pub fn view(&self) -> Rect {
+        self.view
+    }
+
+    /// The canvas size for this viewport.
+    pub fn canvas(&self) -> Expanse {
+        self.canvas
+    }
+
+    /// Set the viewport position. The caller is responsible for ensuring the
+    /// position is valid within the parent canvas.
+    pub fn set_position(&mut self, p: Point) {
+        self.position = p;
+    }
+
+    /// Update the canvas size for this viewport, clamping the current view to
+    /// remain within the new canvas.
+    pub fn set_canvas(&mut self, sz: Expanse) {
+        self.canvas = sz;
+        self.view = match self.view.clamp_within(self.canvas.rect()) {
+            Ok(v) => v,
+            Err(_) => self.canvas.rect(),
+        };
+    }
+
+    /// Set the visible view rectangle, clamped so that it always falls within
+    /// the current canvas.
+    pub fn set_view(&mut self, view: Rect) {
+        self.view = match view.clamp_within(self.canvas.rect()) {
+            Ok(v) => v,
+            Err(_) => self.canvas.rect(),
+        };
     }
 
     /// Scroll the view to the specified position. The view is clamped within

--- a/canopy/src/widgets/editor/editor_impl.rs
+++ b/canopy/src/widgets/editor/editor_impl.rs
@@ -39,7 +39,7 @@ impl Node for EditorView {
     }
 
     fn render(&mut self, _: &dyn Context, r: &mut Render) -> Result<()> {
-        let vo = self.vp().view;
+        let vo = self.vp().view();
         let sr = self.vp().screen_rect();
         self.core.resize_window(sr.w as usize, sr.h as usize);
         for (i, s) in self.core.window_text().iter().enumerate() {

--- a/canopy/src/widgets/frame.rs
+++ b/canopy/src/widgets/frame.rs
@@ -161,7 +161,7 @@ where
         // space is to the right and below.
         for r in self
             .vp()
-            .view
+            .view()
             .inner(1)
             .sub(&self.vp().unproject(self.child.vp().screen_rect())?)
         {

--- a/canopy/src/widgets/input.rs
+++ b/canopy/src/widgets/input.rs
@@ -161,7 +161,7 @@ impl Node for Input {
     }
 
     fn render(&mut self, _: &dyn Context, r: &mut Render) -> Result<()> {
-        r.text("text", self.vp().view.line(0), &self.textbuf.text())
+        r.text("text", self.vp().view().line(0), &self.textbuf.text())
     }
 
     fn handle_key(&mut self, _c: &mut dyn Context, k: key::Key) -> Result<EventOutcome> {

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -127,7 +127,7 @@ where
     /// Make sure the selected item is within the view after a change.
     fn ensure_selected_in_view(&mut self, c: &dyn Context) {
         let virt = self.items[self.offset].virt;
-        let view = self.vp().view;
+        let view = self.vp().view();
         if let Some(v) = virt.vextent().intersection(&view.vextent()) {
             if v.len == virt.h {
                 return;
@@ -151,7 +151,7 @@ where
     /// their offsets and sizes. Items that are offscreen to the side are also
     /// returned, so the returned vector is guaranteed to be a contiguous range.
     fn in_view(&self) -> Vec<usize> {
-        let view = self.vp().view;
+        let view = self.vp().view();
         let mut ret = vec![];
         for (idx, itm) in self.items.iter().enumerate() {
             if view.vextent().intersection(&itm.virt.vextent()).is_some() {
@@ -270,7 +270,7 @@ where
         let mut voffset: u16 = 0;
         for itm in &mut self.items {
             itm.itm.layout(l, r)?;
-            let item_view = itm.itm.vp().canvas.rect();
+            let item_view = itm.itm.vp().canvas().rect();
             itm.virt = item_view.shift(0, voffset as i16);
             voffset += item_view.h;
         }
@@ -284,9 +284,9 @@ where
         for itm in &mut self.items {
             if let Some(child_vp) = vp.map(itm.virt)? {
                 let st = itm.itm.state_mut();
-                st.set_canvas(child_vp.canvas);
-                st.set_view(child_vp.view);
-                st.set_position(child_vp.position);
+                st.set_canvas(child_vp.canvas());
+                st.set_view(child_vp.view());
+                st.set_position(child_vp.position());
                 itm.itm.unhide();
             } else {
                 itm.itm.hide();
@@ -297,7 +297,7 @@ where
     }
 
     fn render(&mut self, _c: &dyn Context, rndr: &mut Render) -> Result<()> {
-        rndr.fill("", self.vp().canvas.rect(), ' ')?;
+        rndr.fill("", self.vp().canvas().rect(), ' ')?;
         Ok(())
     }
 }
@@ -347,7 +347,7 @@ mod tests {
             fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
                 l.fill(self, sz)?;
                 let vp = self.vp();
-                l.place(&mut self.list, vp, vp.view)?;
+                l.place(&mut self.list, vp, vp.view())?;
                 Ok(())
             }
         }
@@ -475,8 +475,8 @@ mod tests {
                 l.place(&mut self.text, vp, Rect::new(0, 0, s.w, s.h))?;
                 let vp = self.text.vp();
                 let sz = Expanse {
-                    w: vp.canvas.w,
-                    h: vp.canvas.h,
+                    w: vp.canvas().w,
+                    h: vp.canvas().h,
                 };
                 l.size(self, sz, sz)?;
                 Ok(())
@@ -514,7 +514,7 @@ mod tests {
             fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
                 l.fill(self, sz)?;
                 let vp = self.vp();
-                l.place(&mut self.frame, vp, vp.view)?;
+                l.place(&mut self.frame, vp, vp.view())?;
                 Ok(())
             }
         }
@@ -525,11 +525,11 @@ mod tests {
 
         canopy.set_root_size(size, &mut root)?;
 
-        let list_rect = root.frame.child.vp().view;
+        let list_rect = root.frame.child.vp().view();
         let mut rects = Vec::new();
         root.frame.child.children(&mut |n| {
             if !n.is_hidden() {
-                rects.push(n.vp().view);
+                rects.push(n.vp().view());
             }
             Ok(())
         })?;
@@ -569,8 +569,8 @@ mod tests {
                 l.place(&mut self.text, vp, Rect::new(0, 0, s.w, s.h))?;
                 let vp = self.text.vp();
                 let sz = Expanse {
-                    w: vp.canvas.w,
-                    h: vp.canvas.h,
+                    w: vp.canvas().w,
+                    h: vp.canvas().h,
                 };
                 l.size(self, sz, sz)?;
                 Ok(())
@@ -609,7 +609,7 @@ mod tests {
             fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
                 l.fill(self, sz)?;
                 let vp = self.vp();
-                l.place(&mut self.frame, vp, vp.view)?;
+                l.place(&mut self.frame, vp, vp.view())?;
                 Ok(())
             }
         }
@@ -680,8 +680,8 @@ mod tests {
                 l.place(&mut self.text, vp, Rect::new(0, 0, s.w, s.h))?;
                 let vp = self.text.vp();
                 let sz = Expanse {
-                    w: vp.canvas.w,
-                    h: vp.canvas.h,
+                    w: vp.canvas().w,
+                    h: vp.canvas().h,
                 };
                 l.size(self, sz, sz)?;
                 Ok(())
@@ -720,7 +720,7 @@ mod tests {
             fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
                 l.fill(self, sz)?;
                 let vp = self.vp();
-                l.place(&mut self.frame, vp, vp.view)?;
+                l.place(&mut self.frame, vp, vp.view())?;
                 Ok(())
             }
         }
@@ -780,8 +780,8 @@ mod tests {
                 )?;
                 let vp = self.text.vp();
                 let sz = Expanse {
-                    w: vp.canvas.w + 2,
-                    h: vp.canvas.h,
+                    w: vp.canvas().w + 2,
+                    h: vp.canvas().h,
                 };
                 l.size(self, sz, sz)?;
                 Ok(())
@@ -802,7 +802,7 @@ mod tests {
 
         impl Node for Status {
             fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
-                r.text("", self.vp().view.line(0), "status")
+                r.text("", self.vp().view().line(0), "status")
             }
         }
 

--- a/canopy/src/widgets/panes.rs
+++ b/canopy/src/widgets/panes.rs
@@ -103,7 +103,7 @@ impl<N: Node> Node for Panes<N> {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
         l.fill(self, sz)?;
         let vp = self.vp();
-        let lst = vp.view.split_panes(&self.shape())?;
+        let lst = vp.view().split_panes(&self.shape())?;
         for (ci, col) in self.children.iter_mut().enumerate() {
             for (ri, row) in col.iter_mut().enumerate() {
                 l.place(row, vp, lst[ci][ri])?;
@@ -196,7 +196,7 @@ mod tests {
         fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
             l.fill(self, sz)?;
             let vp = self.vp();
-            let parts = vp.view.split_horizontal(2)?;
+            let parts = vp.view().split_horizontal(2)?;
             l.place(&mut self.panes, vp, parts[1])?;
             Ok(())
         }
@@ -220,7 +220,7 @@ mod tests {
         fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
             l.fill(self, sz)?;
             let vp = self.vp();
-            let parts = vp.view.split_horizontal(2)?;
+            let parts = vp.view().split_horizontal(2)?;
             l.place(&mut self.panes, vp, parts[1])?;
             Ok(())
         }
@@ -237,8 +237,8 @@ mod tests {
         root.layout(&l, Expanse::new(20, 10))?;
 
         assert_eq!(root.panes.children.len(), 2);
-        assert_eq!(root.panes.children[0][0].vp().position.x, 10);
-        assert_eq!(root.panes.children[1][0].vp().position.x, 15);
+        assert_eq!(root.panes.children[0][0].vp().position().x, 10);
+        assert_eq!(root.panes.children[1][0].vp().position().x, 15);
         Ok(())
     }
 
@@ -331,9 +331,9 @@ mod tests {
 
         root.layout(&l, Expanse::new(20, 10))?;
 
-        let expect = root.panes.vp().view.split_panes(&root.panes.shape())?;
+        let expect = root.panes.vp().view().split_panes(&root.panes.shape())?;
 
-        let off = root.panes.vp().position;
+        let off = root.panes.vp().position();
         let expect: Vec<Vec<Rect>> = expect
             .into_iter()
             .map(|col| {
@@ -392,9 +392,9 @@ mod tests {
 
         root.layout(&l, Expanse::new(20, 10))?;
 
-        let expect = root.panes.vp().view.split_panes(&root.panes.shape())?;
+        let expect = root.panes.vp().view().split_panes(&root.panes.shape())?;
 
-        let off = root.panes.vp().position;
+        let off = root.panes.vp().position();
         let expect: Vec<Vec<Rect>> = expect
             .into_iter()
             .map(|col| {

--- a/canopy/src/widgets/tabs.rs
+++ b/canopy/src/widgets/tabs.rs
@@ -41,7 +41,7 @@ impl Node for Tabs {
     fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
         for (i, rect) in self
             .vp()
-            .view
+            .view()
             .split_horizontal(self.tabs.len() as u16)?
             .iter()
             .enumerate()

--- a/canopy/src/widgets/text.rs
+++ b/canopy/src/widgets/text.rs
@@ -95,7 +95,7 @@ impl Node for Text {
     }
 
     fn render(&mut self, _c: &dyn Context, rndr: &mut Render) -> Result<()> {
-        let vo = self.vp().view;
+        let vo = self.vp().view();
         if let Some(lines) = self.lines.as_ref() {
             for i in 0..vo.h {
                 let out = &lines[(vo.tl.y + i) as usize]

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -72,7 +72,7 @@ impl StatusBar {}
 impl Node for StatusBar {
     fn render(&mut self, _c: &dyn Context, r: &mut Render) -> canopy::Result<()> {
         r.style.push_layer("statusbar");
-        r.text("statusbar/text", self.vp().view.line(0), "todo")?;
+        r.text("statusbar/text", self.vp().view().line(0), "todo")?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- make viewport fields private and add getters/setters
- keep NodeState methods using new viewport API
- update uses across widgets, layout, inspector and examples
- adjust tests and examples to use new methods

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685a1c30d5c08333b325ab7485c973af