### PR TITLE
Enforce viewport validation via setter APIs

### DIFF
--- a/canopy/src/state.rs
+++ b/canopy/src/state.rs
@@ -127,8 +127,8 @@ pub struct NodeState {
 
 impl NodeState {
     /// Set the node's position within the parent canvas.
-    pub fn set_position(&mut self, p: crate::geom::Point) {
-        self.viewport.set_position(p);
+    pub fn set_position(&mut self, p: crate::geom::Point, parent: crate::geom::Expanse) -> crate::Result<()> {
+        self.viewport.set_position(p, parent)
     }
 
     /// Set the size of the node's canvas.
@@ -137,8 +137,8 @@ impl NodeState {
     }
 
     /// Set the portion of the node that is displayed.
-    pub fn set_view(&mut self, view: crate::geom::Rect) {
-        self.viewport.set_view(view);
+    pub fn set_view(&mut self, view: crate::geom::Rect) -> crate::Result<()> {
+        self.viewport.set_view(view)
     }
 
     /// Constrain this viewport so that its screen rectangle falls within the

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -285,12 +285,12 @@ where
             if let Some(child_vp) = vp.map(itm.virt)? {
                 let st = itm.itm.state_mut();
                 st.set_canvas(child_vp.canvas());
-                st.set_view(child_vp.view());
-                st.set_position(child_vp.position());
+                st.set_view(child_vp.view())?;
+                st.set_position(child_vp.position(), vp.canvas())?;
                 itm.itm.unhide();
             } else {
                 itm.itm.hide();
-                itm.itm.state_mut().set_view(Rect::default());
+                itm.itm.state_mut().set_view(Rect::default())?;
             }
         }
         Ok(())

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -153,7 +153,7 @@ impl Node for Todo {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> canopy::Result<()> {
         l.fill(self, sz)?;
         let vp = self.vp();
-        let (a, b) = vp.view.carve_vend(1);
+        let (a, b) = vp.view().carve_vend(1);
         l.place(&mut self.statusbar, vp, b)?;
         l.place(&mut self.content, vp, a)?;
 


### PR DESCRIPTION
## Summary
- update viewport setters to return `Result`
- validate view rectangles within the canvas
- plumb new APIs through NodeState, Layout helpers, and widgets
- fix example to use `ViewPort::view()` accessor

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_685a1b53510c8333911fbe01e671873e