### PR TITLE
Enforce viewport constraints in setters

### DIFF
--- a/canopy/src/state.rs
+++ b/canopy/src/state.rs
@@ -127,8 +127,13 @@ pub struct NodeState {
 
 impl NodeState {
     /// Set the node's position within the parent canvas.
-    pub fn set_position(&mut self, p: crate::geom::Point) {
-        self.viewport.set_position(p);
+    pub fn set_position(
+        &mut self,
+        p: crate::geom::Point,
+        parent_pos: crate::geom::Point,
+        parent_canvas: crate::geom::Rect,
+    ) -> crate::Result<()> {
+        self.viewport.set_position(p, parent_pos, parent_canvas)
     }
 
     /// Set the size of the node's canvas.

--- a/canopy/src/viewport.rs
+++ b/canopy/src/viewport.rs
@@ -89,10 +89,33 @@ impl ViewPort {
         self.canvas
     }
 
-    /// Set the viewport position. The caller is responsible for ensuring the
-    /// position is valid within the parent canvas.
-    pub fn set_position(&mut self, p: Point) {
+    /// Set the viewport position. The caller must provide the parent's position
+    /// and canvas rectangle so that we can verify the new position stays within
+    /// bounds.
+    pub fn set_position(
+        &mut self,
+        p: Point,
+        parent_pos: Point,
+        parent_canvas: Rect,
+    ) -> Result<()> {
+        if p.x < parent_pos.x || p.y < parent_pos.y {
+            return Err(error::Error::Geometry(format!(
+                "position {p:?} before parent origin {parent_pos:?}",
+            )));
+        }
+        let rel = Point {
+            x: p.x - parent_pos.x,
+            y: p.y - parent_pos.y,
+        };
+
+        if !parent_canvas.contains_point(rel) {
+            return Err(error::Error::Geometry(format!(
+                "position {rel:?} outside parent canvas {parent_canvas:?}",
+            )));
+        }
+
         self.position = p;
+        Ok(())
     }
 
     /// Update the canvas size for this viewport, clamping the current view to

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -286,7 +286,11 @@ where
                 let st = itm.itm.state_mut();
                 st.set_canvas(child_vp.canvas());
                 st.set_view(child_vp.view());
-                st.set_position(child_vp.position());
+                st.set_position(
+                    child_vp.position(),
+                    vp.position(),
+                    vp.canvas().rect(),
+                )?;
                 itm.itm.unhide();
             } else {
                 itm.itm.hide();


### PR DESCRIPTION
## Summary
- update `ViewPort::set_position` to check bounds using the parent origin and canvas
- pass parent information through `NodeState::set_position`
- adjust layout helpers and List widget for the new API
- revise layout tests to expect errors when children overflow

## Testing
- `cargo check`
- `cargo test -p canopy --lib -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_685a1b53510c8333911fbe01e671873e