### PR TITLE
Fix clipping of text in Render

### DIFF
--- a/canopy/src/render.rs
+++ b/canopy/src/render.rs
@@ -113,7 +113,7 @@ impl<'a> Render<'a> {
             let out = &txt
                 .chars()
                 .skip(offset as usize)
-                .take(l.w as usize)
+                .take(dst.w as usize)
                 .collect::<String>();
 
             self.backend.text(self.base + dst.tl, out)?;


### PR DESCRIPTION
## Summary
- ensure Render::text clips to projected width

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685a259b4c348333b4460cd0204dd73b