### PR TITLE
Enforce viewport bounds in render

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -283,14 +283,17 @@ where
         let vp = self.vp();
         for itm in &mut self.items {
             if let Some(child_vp) = vp.map(itm.virt)? {
-                let st = itm.itm.state_mut();
-                st.set_canvas(child_vp.canvas());
-                st.set_view(child_vp.view());
-                st.set_position(
-                    child_vp.position(),
-                    vp.position(),
-                    vp.canvas().rect(),
-                )?;
+                {
+                    let st = itm.itm.state_mut();
+                    st.set_position(child_vp.position(), vp.position(), vp.canvas().rect())?;
+                }
+                itm.itm.layout(l, child_vp.screen_rect().expanse())?;
+                {
+                    let st = itm.itm.state_mut();
+                    st.set_canvas(child_vp.canvas());
+                    st.set_view(child_vp.view());
+                    st.constrain(vp);
+                }
                 itm.itm.unhide();
             } else {
                 itm.itm.hide();


### PR DESCRIPTION
## Summary
- assert that each child viewport is contained in its parent during rendering
- update list layout to reposition and constrain items after mapping

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_685a3cd5861c83339fcb2c897c4a58d0