### PR TITLE
Fix horizontal scroll for list widget

### DIFF
--- a/canopy/examples/listgym.rs
+++ b/canopy/examples/listgym.rs
@@ -46,13 +46,14 @@ impl Node for Block {
         // Set our viewport before laying out children so geometry calculations
         // are based on the correct size.
         l.fill(self, target)?;
-        let loc = Rect::new(2, 0, target.w.saturating_sub(2), target.h);
+        let indent = if target.w >= 2 { 2 } else { 0 };
+        let loc = Rect::new(indent, 0, target.w.saturating_sub(indent), target.h);
         let vp = self.vp();
         l.place(&mut self.child, vp, loc)?;
 
         let vp = self.child.vp();
         let sz = Expanse {
-            w: vp.canvas().w + 2,
+            w: vp.canvas().w + indent,
             h: self.child.vp().canvas().h,
         };
         l.size(self, sz, sz)?;


### PR DESCRIPTION
## Summary
- handle narrow Block layout in listgym
- add horizontal scrolling tests for List
- ensure scrolling narrow lists doesn't crash

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685a47cc8af083339650d10e8590a63b