### PR TITLE
Fix horizontal scrolling in list widget

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -286,14 +286,41 @@ where
                 {
                     let st = itm.itm.state_mut();
                     st.set_position(child_vp.position(), vp.position(), vp.canvas().rect())?;
+                    // The item should lay out using its full canvas size so that
+                    // horizontal scrolling only affects the viewport. We set the
+                    // canvas here and expose the entire view for layout.
+                    st.set_canvas(child_vp.canvas());
+                    st.set_view(child_vp.canvas().rect());
                 }
-                itm.itm.layout(l, child_vp.screen_rect().expanse())?;
+                itm.itm.layout(l, child_vp.canvas())?;
                 {
                     let st = itm.itm.state_mut();
-                    st.set_canvas(child_vp.canvas());
+                    // After layout, apply the actual visible view and constrain
+                    // the result within the parent.
                     st.set_view(child_vp.view());
                     st.constrain(vp);
                 }
+                let final_vp = itm.itm.vp();
+                itm.itm.children(&mut |ch| {
+                    let ch_rect = Rect::new(
+                        ch.vp().position().x - final_vp.position().x,
+                        ch.vp().position().y - final_vp.position().y,
+                        ch.vp().canvas().w,
+                        ch.vp().canvas().h,
+                    );
+                    if let Some(ch_vp) = final_vp.map(ch_rect)? {
+                        ch.state_mut().set_position(
+                            ch_vp.position(),
+                            final_vp.position(),
+                            final_vp.canvas().rect(),
+                        )?;
+                        ch.state_mut().set_canvas(ch_vp.canvas());
+                        ch.state_mut().set_view(ch_vp.view());
+                    } else {
+                        ch.state_mut().set_view(Rect::default());
+                    }
+                    Ok(())
+                })?;
                 itm.itm.unhide();
             } else {
                 itm.itm.hide();
@@ -864,6 +891,161 @@ mod tests {
         assert_eq!(canvas.cells[1][3], 'A');
         assert!(canvas.painted[1][3]);
         assert_eq!(canvas.cells[0][0], '┌');
+
+        Ok(())
+    }
+
+    #[test]
+    fn horizontal_scroll_reveals_content() -> Result<()> {
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            list: List<Text>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    list: List::new(vec![Text::new("0123456789").with_fixed_width(10)]),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.list)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.list, vp, vp.view())?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(5, 1);
+        let (buf, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+
+        {
+            let canvas = buf.lock().unwrap();
+            let first: String = canvas.cells[0].iter().collect();
+            assert_eq!(first, "01234");
+        }
+
+        canopy.scroll_right(&mut root.list);
+        canopy.taint_tree(&mut root);
+        canopy.render(&mut cr, &mut root)?;
+
+        {
+            let canvas = buf.lock().unwrap();
+            let second: String = canvas.cells[0].iter().collect();
+            assert_eq!(second, "12345");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn horizontal_scroll_in_frame_reveals_content() -> Result<()> {
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new(t: &str) -> Self {
+                Block {
+                    state: NodeState::default(),
+                    text: Text::new(t).with_fixed_width(t.len() as u16),
+                }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(
+                    &mut self.text,
+                    vp,
+                    Rect::new(2, 0, sz.w.saturating_sub(2), sz.h),
+                )?;
+                let vp = self.text.vp();
+                let sz = Expanse {
+                    w: vp.canvas().w + 2,
+                    h: vp.canvas().h,
+                };
+                l.size(self, sz, sz)?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            frame: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    frame: frame::Frame::new(List::new(vec![Block::new("0123456789")])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.frame)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.frame, vp, vp.view())?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(7, 3);
+        let (buf, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+
+        {
+            let canvas = buf.lock().unwrap();
+            assert_eq!(canvas.cells[1][3], '0');
+        }
+
+        canopy.scroll_right(&mut root.frame.child);
+        canopy.taint_tree(&mut root);
+        canopy.render(&mut cr, &mut root)?;
+
+        {
+            let canvas = buf.lock().unwrap();
+            assert_eq!(canvas.cells[1][3], '1');
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- fix layout of list items so child viewport scrolling propagates to grandchildren
- add regression test for horizontal scrolling in framed list

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685b447e395883338440b2b8df88b024