### PR TITLE
Introduce EventResult to suppress unnecessary renders

### DIFF
--- a/canopy/src/node.rs
+++ b/canopy/src/node.rs
@@ -16,6 +16,42 @@ pub enum EventOutcome {
     Ignore,
 }
 
+/// The result of an event handler.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct EventResult {
+    /// Was the event handled or ignored?
+    pub outcome: EventOutcome,
+    /// If true, handling the event should not trigger a render sweep.
+    pub no_render: bool,
+}
+
+impl From<EventOutcome> for EventResult {
+    fn from(o: EventOutcome) -> Self {
+        EventResult {
+            outcome: o,
+            no_render: false,
+        }
+    }
+}
+
+impl EventResult {
+    /// Convenience to signal that the event was handled and should trigger a render.
+    pub fn handled() -> Self {
+        EventOutcome::Handle.into()
+    }
+
+    /// Convenience to signal that the event was ignored.
+    pub fn ignored() -> Self {
+        EventOutcome::Ignore.into()
+    }
+
+    /// Convenience to mark a handled event that should not trigger rendering.
+    pub fn no_render(mut self) -> Self {
+        self.no_render = true;
+        self
+    }
+}
+
 #[allow(unused_variables)]
 /// Nodes are the basic building-blocks of a Canopy UI. They are composed in a tree, with each node responsible for
 /// managing its own children.
@@ -57,13 +93,13 @@ pub trait Node: StatefulNode + CommandNode {
 
     /// Handle a key input event. This event is only called for nodes that are on the focus path. The default
     /// implementation ignores input.
-    fn handle_key(&mut self, c: &mut dyn Context, k: key::Key) -> Result<EventOutcome> {
-        Ok(EventOutcome::Ignore)
+    fn handle_key(&mut self, c: &mut dyn Context, k: key::Key) -> Result<EventResult> {
+        Ok(EventResult::ignored())
     }
 
     /// Handle a mouse input event. The default implementation ignores mouse input.
-    fn handle_mouse(&mut self, c: &mut dyn Context, k: mouse::MouseEvent) -> Result<EventOutcome> {
-        Ok(EventOutcome::Ignore)
+    fn handle_mouse(&mut self, c: &mut dyn Context, k: mouse::MouseEvent) -> Result<EventResult> {
+        Ok(EventResult::ignored())
     }
 
     /// The scheduled poll endpoint. This function is called for every node the first time it is seen during the

--- a/canopy/src/tutils/ttree.rs
+++ b/canopy/src/tutils/ttree.rs
@@ -78,15 +78,15 @@ macro_rules! leaf {
                     &format!("<{}>", self.name().clone()),
                 )
             }
-            fn handle_key(&mut self, _: &mut dyn Context, _: key::Key) -> Result<EventOutcome> {
-                self.handle("key")
+            fn handle_key(&mut self, _: &mut dyn Context, _: key::Key) -> Result<EventResult> {
+                Ok(self.handle("key")?)
             }
             fn handle_mouse(
                 &mut self,
                 _: &mut dyn Context,
                 _: mouse::MouseEvent,
-            ) -> Result<EventOutcome> {
-                self.handle("mouse")
+            ) -> Result<EventResult> {
+                Ok(self.handle("mouse")?)
             }
         }
 
@@ -118,7 +118,7 @@ macro_rules! leaf {
                 })
             }
 
-            fn handle(&mut self, evt: &str) -> Result<EventOutcome> {
+            fn handle(&mut self, evt: &str) -> Result<EventResult> {
                 let ret = if let Some(x) = self.next_outcome.clone() {
                     self.next_outcome = None;
                     x
@@ -128,7 +128,7 @@ macro_rules! leaf {
                 TSTATE.with(|s| {
                     s.borrow_mut().add_event(&self.name(), evt, ret.clone());
                 });
-                Ok(ret)
+                Ok(ret.into())
             }
         }
     };
@@ -155,7 +155,7 @@ macro_rules! branch {
                     next_outcome: None,
                 }
             }
-            fn handle(&mut self, evt: &str) -> Result<EventOutcome> {
+            fn handle(&mut self, evt: &str) -> Result<EventResult> {
                 let ret = if let Some(x) = self.next_outcome.clone() {
                     self.next_outcome = None;
                     x
@@ -165,7 +165,7 @@ macro_rules! branch {
                 TSTATE.with(|s| {
                     s.borrow_mut().add_event(&self.name(), evt, ret.clone());
                 });
-                Ok(ret)
+                Ok(ret.into())
             }
         }
 
@@ -191,16 +191,16 @@ macro_rules! branch {
                 )
             }
 
-            fn handle_key(&mut self, _: &mut dyn Context, _: key::Key) -> Result<EventOutcome> {
-                self.handle("key")
+            fn handle_key(&mut self, _: &mut dyn Context, _: key::Key) -> Result<EventResult> {
+                Ok(self.handle("key")?)
             }
 
             fn handle_mouse(
                 &mut self,
                 _: &mut dyn Context,
                 _: mouse::MouseEvent,
-            ) -> Result<EventOutcome> {
-                self.handle("mouse")
+            ) -> Result<EventResult> {
+                Ok(self.handle("mouse")?)
             }
 
             fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
@@ -239,7 +239,7 @@ impl R {
         });
         Ok(())
     }
-    fn handle(&mut self, evt: &str) -> Result<EventOutcome> {
+    fn handle(&mut self, evt: &str) -> Result<EventResult> {
         let ret = if let Some(x) = self.next_outcome.clone() {
             self.next_outcome = None;
             x
@@ -249,7 +249,7 @@ impl R {
         TSTATE.with(|s| {
             s.borrow_mut().add_event(&self.name(), evt, ret.clone());
         });
-        Ok(ret)
+        Ok(ret.into())
     }
 }
 
@@ -271,12 +271,12 @@ impl Node for R {
         r.text("any", self.vp().view().line(0), &format!("<{}>", self.name()))
     }
 
-    fn handle_key(&mut self, _: &mut dyn Context, _: key::Key) -> Result<EventOutcome> {
-        self.handle("key")
+    fn handle_key(&mut self, _: &mut dyn Context, _: key::Key) -> Result<EventResult> {
+        Ok(self.handle("key")?)
     }
 
-    fn handle_mouse(&mut self, _: &mut dyn Context, _: mouse::MouseEvent) -> Result<EventOutcome> {
-        self.handle("mouse")
+    fn handle_mouse(&mut self, _: &mut dyn Context, _: mouse::MouseEvent) -> Result<EventResult> {
+        Ok(self.handle("mouse")?)
     }
 
     fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {

--- a/canopy/src/widgets/input.rs
+++ b/canopy/src/widgets/input.rs
@@ -164,16 +164,16 @@ impl Node for Input {
         r.text("text", self.vp().view().line(0), &self.textbuf.text())
     }
 
-    fn handle_key(&mut self, _c: &mut dyn Context, k: key::Key) -> Result<EventOutcome> {
+    fn handle_key(&mut self, _c: &mut dyn Context, k: key::Key) -> Result<EventResult> {
         match k {
             key::Key {
                 mods: _,
                 key: key::KeyCode::Char(c),
             } => {
                 self.textbuf.insert(c);
-                Ok(EventOutcome::Handle)
+                Ok(EventResult::handled())
             }
-            _ => Ok(EventOutcome::Ignore),
+            _ => Ok(EventResult::ignored()),
         }
     }
 


### PR DESCRIPTION
## Summary
- add `EventResult` with `no_render` flag
- use `EventResult` in event handlers and dispatch logic
- ensure `no_render` prevents render sweeps
- add regression test for non-rendering keyboard events

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685b650065848333af6a9e804f868d38