### PR TITLE
Introduce Consume outcome to stop renders on key repeat

### DIFF
--- a/canopy/src/node.rs
+++ b/canopy/src/node.rs
@@ -9,12 +9,20 @@ use crate::{
     Context, Layout, Render, Result,
 };
 
-/// Was an event handled or ignored?
+/// Outcome returned by event handlers.
+///
+/// * `Handle` - The event was handled and the node should be tainted so a render
+///   sweep will occur.
+/// * `Consume` - The event was handled but did not change any visual state. The
+///   event should not be propagated further and the node is **not** tainted.
+/// * `Ignore` - The event was ignored and should be propagated to ancestors.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum EventOutcome {
     Handle,
+    Consume,
     Ignore,
 }
+
 
 #[allow(unused_variables)]
 /// Nodes are the basic building-blocks of a Canopy UI. They are composed in a tree, with each node responsible for

--- a/canopy/src/tutils/ttree.rs
+++ b/canopy/src/tutils/ttree.rs
@@ -27,6 +27,7 @@ impl State {
     pub fn add_event(&mut self, n: &NodeName, evt: &str, result: EventOutcome) {
         let outcome = match result {
             EventOutcome::Handle => "handle",
+            EventOutcome::Consume => "consume",
             EventOutcome::Ignore => "ignore",
         };
         self.path.push(format!("{n}@{evt}->{outcome}"))

--- a/docs/src/keyboard.md
+++ b/docs/src/keyboard.md
@@ -6,4 +6,4 @@ Key events are passed down from the current focus to the root, with the
 **Node::handle_key** method called on each node. Keys are only handled once - we
 stop passing the event along once the first node indicates that it's been
 handled. Handling a key event automatically taints the node, unless the
-**EventResult::no_render** flag in the response object is true.
+event handler returns `EventOutcome::Consume`.

--- a/docs/src/mouse.md
+++ b/docs/src/mouse.md
@@ -6,5 +6,4 @@ Mouse events are independent of the focus - we locate the leaf node that is
 under the mouse cursor, then pass event through the path from the leaf to the
 root for handling. For each node on the path, the **Node::handle_mouse** method
 is called, and we stop after the first node handles the event. Handling a mouse
-event taints the node, unless the **EventResult::no_render** flag on the
-response object is true.
+event taints the node unless the handler returns `EventOutcome::Consume`.


### PR DESCRIPTION
## Summary
- extend `EventOutcome` with `Consume` variant
- remove `EventResult` and update event APIs
- use `Consume` in event dispatch logic
- update tests and documentation

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685b650065848333af6a9e804f868d38