### PR TITLE
Introduce Consume event outcome

### DIFF
--- a/canopy/src/layout.rs
+++ b/canopy/src/layout.rs
@@ -46,13 +46,13 @@ impl Layout {
 
     /// Place a child in a given sub-rectangle of a parent's view.
     pub fn place(&self, child: &mut dyn Node, parent_vp: ViewPort, loc: Rect) -> Result<()> {
-        child
-            .state_mut()
-            .set_position(
-                parent_vp.position().scroll(loc.tl.x as i16, loc.tl.y as i16),
-                parent_vp.position(),
-                parent_vp.canvas().rect(),
-            )?;
+        child.state_mut().set_position(
+            parent_vp
+                .position()
+                .scroll(loc.tl.x as i16, loc.tl.y as i16),
+            parent_vp.position(),
+            parent_vp.canvas().rect(),
+        )?;
         child.layout(self, loc.expanse())?;
         child.state_mut().constrain(parent_vp);
         Ok(())
@@ -67,12 +67,11 @@ impl Layout {
     /// adjusts the node's view to place as much of it within the viewport's screen rectangle as possible.
     pub fn fit(&self, n: &mut dyn Node, parent_vp: ViewPort) -> Result<()> {
         n.layout(self, parent_vp.screen_rect().into())?;
-        n.state_mut()
-            .set_position(
-                parent_vp.position(),
-                parent_vp.position(),
-                parent_vp.canvas().rect(),
-            )?;
+        n.state_mut().set_position(
+            parent_vp.position(),
+            parent_vp.position(),
+            parent_vp.canvas().rect(),
+        )?;
         n.state_mut().constrain(parent_vp);
         Ok(())
     }

--- a/canopy/src/node.rs
+++ b/canopy/src/node.rs
@@ -9,12 +9,19 @@ use crate::{
     Context, Layout, Render, Result,
 };
 
-/// Was an event handled or ignored?
+/// The result of an event handler.
+///
+/// * `Handle` - the event was processed and the node should be rendered.
+/// * `Consume` - the event was processed, but nothing changed so rendering is
+///   skipped and propagation stops.
+/// * `Ignore` - the event was not handled and will bubble up the tree.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum EventOutcome {
     Handle,
+    Consume,
     Ignore,
 }
+
 
 #[allow(unused_variables)]
 /// Nodes are the basic building-blocks of a Canopy UI. They are composed in a tree, with each node responsible for

--- a/canopy/src/node.rs
+++ b/canopy/src/node.rs
@@ -22,7 +22,6 @@ pub enum EventOutcome {
     Ignore,
 }
 
-
 #[allow(unused_variables)]
 /// Nodes are the basic building-blocks of a Canopy UI. They are composed in a tree, with each node responsible for
 /// managing its own children.

--- a/canopy/src/tutils/mod.rs
+++ b/canopy/src/tutils/mod.rs
@@ -83,7 +83,7 @@ impl Context for DummyContext {
     fn needs_render(&self, _n: &dyn Node) -> bool {
         false
     }
-    fn set_focus(&mut self, _n: &mut dyn Node) {}
+    fn set_focus(&mut self, _n: &mut dyn Node) -> bool { false }
     fn focus_dir(&mut self, _root: &mut dyn Node, _dir: Direction) {}
     fn taint(&mut self, _n: &mut dyn Node) {}
     fn taint_tree(&mut self, _e: &mut dyn Node) {}

--- a/canopy/src/tutils/mod.rs
+++ b/canopy/src/tutils/mod.rs
@@ -83,8 +83,34 @@ impl Context for DummyContext {
     fn needs_render(&self, _n: &dyn Node) -> bool {
         false
     }
-    fn set_focus(&mut self, _n: &mut dyn Node) -> bool { false }
+    fn set_focus(&mut self, _n: &mut dyn Node) -> bool {
+        false
+    }
     fn focus_dir(&mut self, _root: &mut dyn Node, _dir: Direction) {}
+    fn scroll_to(&self, _n: &mut dyn Node, _x: u16, _y: u16) -> bool {
+        false
+    }
+    fn scroll_by(&self, _n: &mut dyn Node, _x: i16, _y: i16) -> bool {
+        false
+    }
+    fn page_up(&self, _n: &mut dyn Node) -> bool {
+        false
+    }
+    fn page_down(&self, _n: &mut dyn Node) -> bool {
+        false
+    }
+    fn scroll_up(&self, _n: &mut dyn Node) -> bool {
+        false
+    }
+    fn scroll_down(&self, _n: &mut dyn Node) -> bool {
+        false
+    }
+    fn scroll_left(&self, _n: &mut dyn Node) -> bool {
+        false
+    }
+    fn scroll_right(&self, _n: &mut dyn Node) -> bool {
+        false
+    }
     fn taint(&mut self, _n: &mut dyn Node) {}
     fn taint_tree(&mut self, _e: &mut dyn Node) {}
 
@@ -101,6 +127,10 @@ impl Context for DummyContext {
     /// Stop the render backend and exit the process.
     fn exit(&mut self, _code: i32) -> ! {
         panic!("exit in dummy core")
+    }
+
+    fn current_focus_gen(&self) -> u64 {
+        0
     }
 }
 

--- a/canopy/src/tutils/ttree.rs
+++ b/canopy/src/tutils/ttree.rs
@@ -269,7 +269,11 @@ impl Node for R {
     }
 
     fn render(&mut self, _c: &dyn Context, r: &mut Render) -> Result<()> {
-        r.text("any", self.vp().view().line(0), &format!("<{}>", self.name()))
+        r.text(
+            "any",
+            self.vp().view().line(0),
+            &format!("<{}>", self.name()),
+        )
     }
 
     fn handle_key(&mut self, _: &mut dyn Context, _: key::Key) -> Result<EventOutcome> {

--- a/canopy/src/tutils/ttree.rs
+++ b/canopy/src/tutils/ttree.rs
@@ -27,6 +27,7 @@ impl State {
     pub fn add_event(&mut self, n: &NodeName, evt: &str, result: EventOutcome) {
         let outcome = match result {
             EventOutcome::Handle => "handle",
+            EventOutcome::Consume => "consume",
             EventOutcome::Ignore => "ignore",
         };
         self.path.push(format!("{n}@{evt}->{outcome}"))

--- a/canopy/src/viewport.rs
+++ b/canopy/src/viewport.rs
@@ -92,12 +92,7 @@ impl ViewPort {
     /// Set the viewport position. The caller must provide the parent's position
     /// and canvas rectangle so that we can verify the new position stays within
     /// bounds.
-    pub fn set_position(
-        &mut self,
-        p: Point,
-        parent_pos: Point,
-        parent_canvas: Rect,
-    ) -> Result<()> {
+    pub fn set_position(&mut self, p: Point, parent_pos: Point, parent_canvas: Rect) -> Result<()> {
         if p.x < parent_pos.x || p.y < parent_pos.y {
             return Err(error::Error::Geometry(format!(
                 "position {p:?} before parent origin {parent_pos:?}",

--- a/canopy/src/widgets/input.rs
+++ b/canopy/src/widgets/input.rs
@@ -68,32 +68,44 @@ impl TextBuf {
         };
     }
 
-    pub fn goto(&mut self, loc: u16) {
+    pub fn goto(&mut self, loc: u16) -> bool {
+        let changed = self.cursor_pos != loc;
         self.cursor_pos = loc;
         self.fix_window();
+        changed
     }
-    pub fn insert(&mut self, c: char) {
+    pub fn insert(&mut self, c: char) -> bool {
         self.value.insert(self.cursor_pos as usize, c);
         self.cursor_pos += 1;
         self.fix_window();
+        true
     }
-    pub fn backspace(&mut self) {
+    pub fn backspace(&mut self) -> bool {
         if !self.value.is_empty() && self.cursor_pos > 0 {
             self.value.remove(self.cursor_pos as usize - 1);
             self.cursor_pos -= 1;
             self.fix_window();
+            true
+        } else {
+            false
         }
     }
-    pub fn left(&mut self) {
+    pub fn left(&mut self) -> bool {
         if self.cursor_pos > 0 {
             self.cursor_pos -= 1;
             self.fix_window();
+            true
+        } else {
+            false
         }
     }
-    pub fn right(&mut self) {
+    pub fn right(&mut self) -> bool {
         if self.cursor_pos < self.value.len() as u16 {
             self.cursor_pos += 1;
             self.fix_window();
+            true
+        } else {
+            false
         }
     }
 }
@@ -119,20 +131,26 @@ impl Input {
 
     /// Move the cursor left.
     #[command]
-    fn left(&mut self, _: &dyn Context) {
-        self.textbuf.left();
+    fn left(&mut self, c: &mut dyn Context) {
+        if self.textbuf.left() {
+            c.taint(self);
+        }
     }
 
     /// Move the cursor right.
     #[command]
-    fn right(&mut self, _: &dyn Context) {
-        self.textbuf.right();
+    fn right(&mut self, c: &mut dyn Context) {
+        if self.textbuf.right() {
+            c.taint(self);
+        }
     }
 
     /// Delete a character at the input location.
     #[command]
-    fn backspace(&mut self, _: &dyn Context) {
-        self.textbuf.backspace();
+    fn backspace(&mut self, c: &mut dyn Context) {
+        if self.textbuf.backspace() {
+            c.taint(self);
+        }
     }
 }
 

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -59,7 +59,7 @@ where
             state: NodeState::default(),
         };
         if !l.is_empty() {
-            l.select(0);
+            l.items[0].set_selected(true);
         }
         l
     }

--- a/docs/src/keyboard.md
+++ b/docs/src/keyboard.md
@@ -6,4 +6,4 @@ Key events are passed down from the current focus to the root, with the
 **Node::handle_key** method called on each node. Keys are only handled once - we
 stop passing the event along once the first node indicates that it's been
 handled. Handling a key event automatically taints the node, unless the
-**EventResult::no_render** flag in the response object is true.
+**EventOutcome::Consume** value is returned.

--- a/docs/src/mouse.md
+++ b/docs/src/mouse.md
@@ -6,5 +6,4 @@ Mouse events are independent of the focus - we locate the leaf node that is
 under the mouse cursor, then pass event through the path from the leaf to the
 root for handling. For each node on the path, the **Node::handle_mouse** method
 is called, and we stop after the first node handles the event. Handling a mouse
-event taints the node, unless the **EventResult::no_render** flag on the
-response object is true.
+event taints the node, unless **EventOutcome::Consume** is returned.


### PR DESCRIPTION
## Summary
- add `Consume` variant to `EventOutcome` and document behavior
- update Context::set_focus to return bool and skip updates when focus is unchanged
- adjust dummy context for new method

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685b650065848333af6a9e804f868d38