### PR TITLE
Fix focus search runaway loops

### DIFF
--- a/canopy/src/canopy.rs
+++ b/canopy/src/canopy.rs
@@ -242,9 +242,16 @@ impl Context for Canopy {
         let mut seen = false;
         let mut last = None;
         if let Some(start) = self.focus_area(root) {
+            let bounds = self
+                .root_size
+                .unwrap_or_else(|| Expanse::new(u16::MAX, u16::MAX));
+
             start
                 .search(dir, &mut |p| -> Result<bool> {
-                    if seen {
+                    if seen
+                        || p.x >= bounds.w
+                        || p.y >= bounds.h
+                    {
                         return Ok(true);
                     }
                     let n = node_at(root, p);


### PR DESCRIPTION
## Summary
- avoid unbounded focus search when using directional focus moves

## Testing
- `cargo test --no-run --all`

------
https://chatgpt.com/codex/tasks/task_e_685ca1a1fa5c8333b0a24ac8eb1678f0