### PR TITLE
Fix text scrolling

### DIFF
--- a/canopy/src/canopy.rs
+++ b/canopy/src/canopy.rs
@@ -68,62 +68,94 @@ pub trait Context {
 
     /// Scroll the view to the specified position. The view is clamped within
     /// the outer rectangle. Returns `true` if the view changed.
-    fn scroll_to(&self, n: &mut dyn Node, x: u16, y: u16) -> bool {
+    fn scroll_to(&mut self, n: &mut dyn Node, x: u16, y: u16) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_to(x, y);
-        before != n.vp().view()
+        let changed = before != n.vp().view();
+        if changed {
+            self.taint_tree(n);
+        }
+        changed
     }
 
     /// Scroll the view by the given offsets. The view rectangle is clamped
     /// within the outer rectangle. Returns `true` if the view changed.
-    fn scroll_by(&self, n: &mut dyn Node, x: i16, y: i16) -> bool {
+    fn scroll_by(&mut self, n: &mut dyn Node, x: i16, y: i16) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_by(x, y);
-        before != n.vp().view()
+        let changed = before != n.vp().view();
+        if changed {
+            self.taint_tree(n);
+        }
+        changed
     }
 
     /// Scroll the view up by the height of the view rectangle. Returns `true`
     /// if the view changed.
-    fn page_up(&self, n: &mut dyn Node) -> bool {
+    fn page_up(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().page_up();
-        before != n.vp().view()
+        let changed = before != n.vp().view();
+        if changed {
+            self.taint_tree(n);
+        }
+        changed
     }
 
     /// Scroll the view down by the height of the view rectangle. Returns `true`
     /// if the view changed.
-    fn page_down(&self, n: &mut dyn Node) -> bool {
+    fn page_down(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().page_down();
-        before != n.vp().view()
+        let changed = before != n.vp().view();
+        if changed {
+            self.taint_tree(n);
+        }
+        changed
     }
 
     /// Scroll the view up by one line. Returns `true` if the view changed.
-    fn scroll_up(&self, n: &mut dyn Node) -> bool {
+    fn scroll_up(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_up();
-        before != n.vp().view()
+        let changed = before != n.vp().view();
+        if changed {
+            self.taint_tree(n);
+        }
+        changed
     }
 
     /// Scroll the view down by one line. Returns `true` if the view changed.
-    fn scroll_down(&self, n: &mut dyn Node) -> bool {
+    fn scroll_down(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_down();
-        before != n.vp().view()
+        let changed = before != n.vp().view();
+        if changed {
+            self.taint_tree(n);
+        }
+        changed
     }
 
     /// Scroll the view left by one line. Returns `true` if the view changed.
-    fn scroll_left(&self, n: &mut dyn Node) -> bool {
+    fn scroll_left(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_left();
-        before != n.vp().view()
+        let changed = before != n.vp().view();
+        if changed {
+            self.taint_tree(n);
+        }
+        changed
     }
 
     /// Scroll the view right by one line. Returns `true` if the view changed.
-    fn scroll_right(&self, n: &mut dyn Node) -> bool {
+    fn scroll_right(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_right();
-        before != n.vp().view()
+        let changed = before != n.vp().view();
+        if changed {
+            self.taint_tree(n);
+        }
+        changed
     }
 
     /// Taint a node to signal that it should be re-rendered.

--- a/canopy/src/canopy.rs
+++ b/canopy/src/canopy.rs
@@ -67,7 +67,8 @@ pub trait Context {
     fn focus_dir(&mut self, root: &mut dyn Node, dir: Direction);
 
     /// Scroll the view to the specified position. The view is clamped within
-    /// the outer rectangle. Returns `true` if the view changed.
+    /// the outer rectangle. Returns `true` if movement occurred and taints the
+    /// subtree on change.
     fn scroll_to(&mut self, n: &mut dyn Node, x: u16, y: u16) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_to(x, y);
@@ -79,7 +80,8 @@ pub trait Context {
     }
 
     /// Scroll the view by the given offsets. The view rectangle is clamped
-    /// within the outer rectangle. Returns `true` if the view changed.
+    /// within the outer rectangle. Returns `true` if movement occurred and
+    /// taints the subtree on change.
     fn scroll_by(&mut self, n: &mut dyn Node, x: i16, y: i16) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_by(x, y);
@@ -90,8 +92,8 @@ pub trait Context {
         changed
     }
 
-    /// Scroll the view up by the height of the view rectangle. Returns `true`
-    /// if the view changed.
+    /// Scroll the view up by one page. Returns `true` if movement occurred and
+    /// taints the subtree on change.
     fn page_up(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().page_up();
@@ -102,8 +104,8 @@ pub trait Context {
         changed
     }
 
-    /// Scroll the view down by the height of the view rectangle. Returns `true`
-    /// if the view changed.
+    /// Scroll the view down by one page. Returns `true` if movement occurred
+    /// and taints the subtree on change.
     fn page_down(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().page_down();
@@ -114,7 +116,8 @@ pub trait Context {
         changed
     }
 
-    /// Scroll the view up by one line. Returns `true` if the view changed.
+    /// Scroll the view up by one line. Returns `true` if movement occurred and
+    /// taints the subtree on change.
     fn scroll_up(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_up();
@@ -125,7 +128,8 @@ pub trait Context {
         changed
     }
 
-    /// Scroll the view down by one line. Returns `true` if the view changed.
+    /// Scroll the view down by one line. Returns `true` if movement occurred
+    /// and taints the subtree on change.
     fn scroll_down(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_down();
@@ -136,7 +140,8 @@ pub trait Context {
         changed
     }
 
-    /// Scroll the view left by one line. Returns `true` if the view changed.
+    /// Scroll the view left by one line. Returns `true` if movement occurred
+    /// and taints the subtree on change.
     fn scroll_left(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_left();
@@ -147,7 +152,8 @@ pub trait Context {
         changed
     }
 
-    /// Scroll the view right by one line. Returns `true` if the view changed.
+    /// Scroll the view right by one line. Returns `true` if movement occurred
+    /// and taints the subtree on change.
     fn scroll_right(&mut self, n: &mut dyn Node) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_right();

--- a/canopy/src/tutils/mod.rs
+++ b/canopy/src/tutils/mod.rs
@@ -87,28 +87,28 @@ impl Context for DummyContext {
         false
     }
     fn focus_dir(&mut self, _root: &mut dyn Node, _dir: Direction) {}
-    fn scroll_to(&self, _n: &mut dyn Node, _x: u16, _y: u16) -> bool {
+    fn scroll_to(&mut self, _n: &mut dyn Node, _x: u16, _y: u16) -> bool {
         false
     }
-    fn scroll_by(&self, _n: &mut dyn Node, _x: i16, _y: i16) -> bool {
+    fn scroll_by(&mut self, _n: &mut dyn Node, _x: i16, _y: i16) -> bool {
         false
     }
-    fn page_up(&self, _n: &mut dyn Node) -> bool {
+    fn page_up(&mut self, _n: &mut dyn Node) -> bool {
         false
     }
-    fn page_down(&self, _n: &mut dyn Node) -> bool {
+    fn page_down(&mut self, _n: &mut dyn Node) -> bool {
         false
     }
-    fn scroll_up(&self, _n: &mut dyn Node) -> bool {
+    fn scroll_up(&mut self, _n: &mut dyn Node) -> bool {
         false
     }
-    fn scroll_down(&self, _n: &mut dyn Node) -> bool {
+    fn scroll_down(&mut self, _n: &mut dyn Node) -> bool {
         false
     }
-    fn scroll_left(&self, _n: &mut dyn Node) -> bool {
+    fn scroll_left(&mut self, _n: &mut dyn Node) -> bool {
         false
     }
-    fn scroll_right(&self, _n: &mut dyn Node) -> bool {
+    fn scroll_right(&mut self, _n: &mut dyn Node) -> bool {
         false
     }
     fn taint(&mut self, _n: &mut dyn Node) {}

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -232,49 +232,37 @@ where
     /// Scroll the viewport down by one line.
     #[command]
     pub fn scroll_down(&mut self, c: &mut dyn Context) {
-        if c.scroll_down(self) {
-            c.taint(self);
-        }
+        c.scroll_down(self);
     }
 
     /// Scroll the viewport up by one line.
     #[command]
     pub fn scroll_up(&mut self, c: &mut dyn Context) {
-        if c.scroll_up(self) {
-            c.taint(self);
-        }
+        c.scroll_up(self);
     }
 
     /// Scroll the viewport left by one column.
     #[command]
     pub fn scroll_left(&mut self, c: &mut dyn Context) {
-        if c.scroll_left(self) {
-            c.taint(self);
-        }
+        c.scroll_left(self);
     }
 
     /// Scroll the viewport right by one column.
     #[command]
     pub fn scroll_right(&mut self, c: &mut dyn Context) {
-        if c.scroll_right(self) {
-            c.taint(self);
-        }
+        c.scroll_right(self);
     }
 
     /// Scroll the viewport down by one page.
     #[command]
     pub fn page_down(&mut self, c: &mut dyn Context) {
-        if c.page_down(self) {
-            c.taint(self);
-        }
+        c.page_down(self);
     }
 
     /// Scroll the viewport up by one page.
     #[command]
     pub fn page_up(&mut self, c: &mut dyn Context) {
-        if c.page_up(self) {
-            c.taint(self);
-        }
+        c.page_up(self);
     }
 }
 
@@ -432,7 +420,6 @@ mod tests {
         let corner = first[0][0];
 
         canopy.scroll_down(&mut root.list.child);
-        canopy.taint_tree(&mut root);
         canopy.render(&mut cr, &mut root)?;
         let second = buf.lock().unwrap().cells.clone();
 
@@ -442,7 +429,6 @@ mod tests {
         assert_eq!(second[(size.h - 1) as usize], bottom);
 
         canopy.scroll_up(&mut root.list.child);
-        canopy.taint_tree(&mut root);
         canopy.render(&mut cr, &mut root)?;
         let third = buf.lock().unwrap().cells.clone();
 
@@ -693,7 +679,6 @@ mod tests {
         }
 
         canopy.scroll_down(&mut root.frame.child);
-        canopy.taint_tree(&mut root);
         canopy.render(&mut pr, &mut root)?;
         {
             let painted = buf.lock().unwrap();
@@ -703,7 +688,6 @@ mod tests {
         }
 
         canopy.scroll_up(&mut root.frame.child);
-        canopy.taint_tree(&mut root);
         canopy.render(&mut pr, &mut root)?;
         {
             let painted = buf.lock().unwrap();
@@ -971,7 +955,6 @@ mod tests {
         }
 
         canopy.scroll_right(&mut root.list);
-        canopy.taint_tree(&mut root);
         canopy.render(&mut cr, &mut root)?;
 
         {
@@ -1069,7 +1052,6 @@ mod tests {
         }
 
         canopy.scroll_right(&mut root.frame.child);
-        canopy.taint_tree(&mut root);
         canopy.render(&mut cr, &mut root)?;
 
         {

--- a/canopy/src/widgets/text.rs
+++ b/canopy/src/widgets/text.rs
@@ -36,37 +36,51 @@ impl Text {
 
     #[command]
     pub fn scroll_to_top(&mut self, c: &mut dyn Context) {
-        c.scroll_to(self, 0, 0);
+        if c.scroll_to(self, 0, 0) {
+            c.taint(self);
+        }
     }
 
     #[command]
     pub fn scroll_down(&mut self, c: &mut dyn Context) {
-        c.scroll_down(self);
+        if c.scroll_down(self) {
+            c.taint(self);
+        }
     }
 
     #[command]
     pub fn scroll_up(&mut self, c: &mut dyn Context) {
-        c.scroll_up(self);
+        if c.scroll_up(self) {
+            c.taint(self);
+        }
     }
 
     #[command]
     pub fn scroll_left(&mut self, c: &mut dyn Context) {
-        c.scroll_left(self);
+        if c.scroll_left(self) {
+            c.taint(self);
+        }
     }
 
     #[command]
     pub fn scroll_right(&mut self, c: &mut dyn Context) {
-        c.scroll_right(self);
+        if c.scroll_right(self) {
+            c.taint(self);
+        }
     }
 
     #[command]
     pub fn page_down(&mut self, c: &mut dyn Context) {
-        c.page_down(self);
+        if c.page_down(self) {
+            c.taint(self);
+        }
     }
 
     #[command]
     pub fn page_up(&mut self, c: &mut dyn Context) {
-        c.page_up(self);
+        if c.page_up(self) {
+            c.taint(self);
+        }
     }
 }
 

--- a/canopy/src/widgets/text.rs
+++ b/canopy/src/widgets/text.rs
@@ -36,51 +36,37 @@ impl Text {
 
     #[command]
     pub fn scroll_to_top(&mut self, c: &mut dyn Context) {
-        if c.scroll_to(self, 0, 0) {
-            c.taint(self);
-        }
+        c.scroll_to(self, 0, 0);
     }
 
     #[command]
     pub fn scroll_down(&mut self, c: &mut dyn Context) {
-        if c.scroll_down(self) {
-            c.taint(self);
-        }
+        c.scroll_down(self);
     }
 
     #[command]
     pub fn scroll_up(&mut self, c: &mut dyn Context) {
-        if c.scroll_up(self) {
-            c.taint(self);
-        }
+        c.scroll_up(self);
     }
 
     #[command]
     pub fn scroll_left(&mut self, c: &mut dyn Context) {
-        if c.scroll_left(self) {
-            c.taint(self);
-        }
+        c.scroll_left(self);
     }
 
     #[command]
     pub fn scroll_right(&mut self, c: &mut dyn Context) {
-        if c.scroll_right(self) {
-            c.taint(self);
-        }
+        c.scroll_right(self);
     }
 
     #[command]
     pub fn page_down(&mut self, c: &mut dyn Context) {
-        if c.page_down(self) {
-            c.taint(self);
-        }
+        c.page_down(self);
     }
 
     #[command]
     pub fn page_up(&mut self, c: &mut dyn Context) {
-        if c.page_up(self) {
-            c.taint(self);
-        }
+        c.page_up(self);
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure text widget requests re-render when scrolled

## Testing
- `cargo test --quiet`
- `cargo build --quiet --example pager`


------
https://chatgpt.com/codex/tasks/task_e_685ca3c1f518833382bf43503c458044