### PR TITLE
Fix stack overflow in intervals example

### DIFF
--- a/canopy/examples/intervals.rs
+++ b/canopy/examples/intervals.rs
@@ -50,7 +50,7 @@ impl Node for IntervalItem {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
         self.child.layout(l, sz)?;
         let vp = self.child.vp();
-        l.fit(self, vp)?;
+        l.size(self, vp.canvas(), vp.canvas())?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- avoid recursive Layout::fit in `IntervalItem` layout

## Testing
- `cargo build --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685cba8727c08333b630a413e84b912e