### PR TITLE
Fix child repositioning after viewport constrain

### DIFF
--- a/canopy/examples/intervals.rs
+++ b/canopy/examples/intervals.rs
@@ -50,7 +50,7 @@ impl Node for IntervalItem {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
         self.child.layout(l, sz)?;
         let vp = self.child.vp();
-        l.fit(self, vp)?;
+        l.wrap(self, vp)?;
         Ok(())
     }
 

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -319,10 +319,13 @@ where
                     st.constrain(vp);
                 }
                 let final_vp = itm.itm.vp();
+                let dx = final_vp.position().x as i16 - child_vp.position().x as i16;
+                let dy = final_vp.position().y as i16 - child_vp.position().y as i16;
                 itm.itm.children(&mut |ch| {
+                    let pos = ch.vp().position().scroll(dx, dy);
                     let ch_rect = Rect::new(
-                        ch.vp().position().x - final_vp.position().x,
-                        ch.vp().position().y - final_vp.position().y,
+                        pos.x.saturating_sub(final_vp.position().x),
+                        pos.y.saturating_sub(final_vp.position().y),
                         ch.vp().canvas().w,
                         ch.vp().canvas().h,
                     );


### PR DESCRIPTION
## Summary
- update list widget to keep children aligned when parent view is clipped

## Testing
- `cargo test -q -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_685cba8727c08333b630a413e84b912e