### PR TITLE
Fix stack overflow in intervals example

### DIFF
--- a/canopy/examples/intervals.rs
+++ b/canopy/examples/intervals.rs
@@ -50,7 +50,7 @@ impl Node for IntervalItem {
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
         self.child.layout(l, sz)?;
         let vp = self.child.vp();
-        l.fit(self, vp)?;
+        l.wrap(self, vp)?;
         Ok(())
     }
 

--- a/canopy/src/layout.rs
+++ b/canopy/src/layout.rs
@@ -9,6 +9,11 @@ pub struct Layout {}
 
 impl Layout {
     /// Wrap a single child node, mirroring the child's size and view.
+    ///
+    /// When implementing a simple container that merely exposes its child's
+    /// viewport, prefer this over [`fit`]. Calling `fit` recursively from a
+    /// widget's `layout` method can lead to unbounded recursion and a stack
+    /// overflow.
     pub fn wrap(&self, parent: &mut dyn Node, vp: ViewPort) -> Result<()> {
         // Mirror the child's size and view
         parent.state_mut().set_canvas(vp.canvas());
@@ -63,8 +68,13 @@ impl Layout {
         Ok(())
     }
 
-    /// Adjust a child node so that it fits a viewport. This lays the node out to the viewport's screen rectangle, then
-    /// adjusts the node's view to place as much of it within the viewport's screen rectangle as possible.
+    /// Adjust a child node so that it fits a viewport. This lays the node out to
+    /// the viewport's screen rectangle, then adjusts the node's view to place as
+    /// much of it within the viewport's screen rectangle as possible.
+    ///
+    /// Note that [`fit`] will call the child's [`Node::layout`] method. Calling
+    /// `fit` on a node from within its own `layout` implementation will recurse
+    /// endlessly.
     pub fn fit(&self, n: &mut dyn Node, parent_vp: ViewPort) -> Result<()> {
         n.layout(self, parent_vp.screen_rect().into())?;
         n.state_mut().set_position(

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -320,9 +320,15 @@ where
                 }
                 let final_vp = itm.itm.vp();
                 itm.itm.children(&mut |ch| {
+                    // `ch.vp().position()` returns absolute co-ordinates. We
+                    // want a rectangle relative to the item's canvas, so we
+                    // calculate the offset from the item's position. Use
+                    // `saturating_sub` to avoid panics if the child hasn't been
+                    // repositioned yet and lies above or to the left of the
+                    // item.
                     let ch_rect = Rect::new(
-                        ch.vp().position().x - final_vp.position().x,
-                        ch.vp().position().y - final_vp.position().y,
+                        ch.vp().position().x.saturating_sub(final_vp.position().x),
+                        ch.vp().position().y.saturating_sub(final_vp.position().y),
                         ch.vp().canvas().w,
                         ch.vp().canvas().h,
                     );
@@ -335,6 +341,14 @@ where
                         ch.state_mut().set_canvas(ch_vp.canvas());
                         ch.state_mut().set_view(ch_vp.view());
                     } else {
+                        // Even if the child is fully clipped, ensure it stays
+                        // at a valid position relative to the item so that
+                        // invariants hold.
+                        ch.state_mut().set_position(
+                            final_vp.position(),
+                            final_vp.position(),
+                            final_vp.canvas().rect(),
+                        )?;
                         ch.state_mut().set_view(Rect::default());
                     }
                     Ok(())
@@ -343,6 +357,15 @@ where
             } else {
                 itm.itm.hide();
                 itm.itm.state_mut().set_view(Rect::default());
+                // Ensure hidden items cannot violate viewport invariants by
+                // explicitly hiding their children too. Newly added items may
+                // not have been positioned yet, leaving child viewports at the
+                // origin.
+                itm.itm.children(&mut |ch| {
+                    ch.hide();
+                    ch.state_mut().set_view(Rect::default());
+                    Ok(())
+                })?;
             }
         }
         Ok(())
@@ -1058,6 +1081,272 @@ mod tests {
             let canvas = buf.lock().unwrap();
             assert_eq!(canvas.cells[1][3], '1');
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn append_item_clipped_bounds() -> Result<()> {
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new(t: &str) -> Self {
+                Block {
+                    state: NodeState::default(),
+                    text: Text::new(t).with_fixed_width(t.len() as u16),
+                }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.text, vp, Rect::new(0, 0, sz.w, sz.h))?;
+                let vp = self.text.vp();
+                l.size(self, vp.canvas(), vp.canvas())?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            list: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    list: frame::Frame::new(List::new(vec![Block::new("A"), Block::new("B")])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.list)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.list, vp, vp.view())?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(4, 3);
+        let (_, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+
+        // Append a new item that will be outside the visible view.
+        root.list.child.append(Block::new("C"));
+        canopy.render(&mut cr, &mut root)?;
+
+        let list_rect = root.list.child.vp().screen_rect();
+        root.list.child.children(&mut |n| {
+            if !n.is_hidden() {
+                assert!(list_rect.contains_rect(&n.vp().screen_rect()));
+            }
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn append_interval_item_no_overflow() -> Result<()> {
+        #[derive(StatefulNode)]
+        struct IntervalItem {
+            state: NodeState,
+            child: Text,
+            selected: bool,
+        }
+
+        #[derive_commands]
+        impl IntervalItem {
+            fn new() -> Self {
+                IntervalItem {
+                    state: NodeState::default(),
+                    child: Text::new("0"),
+                    selected: false,
+                }
+            }
+        }
+
+        impl ListItem for IntervalItem {
+            fn set_selected(&mut self, state: bool) {
+                self.selected = state;
+            }
+        }
+
+        impl Node for IntervalItem {
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                self.child.layout(l, sz)?;
+                let vp = self.child.vp();
+                l.wrap(self, vp)?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.child)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            list: frame::Frame<List<IntervalItem>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    list: frame::Frame::new(List::new(vec![])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.list)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.list, vp, vp.view())?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(10, 3);
+        let (_, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+
+        // Append a new item and render again. This previously triggered an
+        // invariant violation.
+        root.list.child.append(IntervalItem::new());
+        canopy.render(&mut cr, &mut root)?;
+
+        let list_rect = root.list.child.vp().screen_rect();
+        root.list.child.children(&mut |n| {
+            if !n.is_hidden() {
+                assert!(list_rect.contains_rect(&n.vp().screen_rect()));
+            }
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn hidden_item_hides_children() -> Result<()> {
+        #[derive(StatefulNode)]
+        struct Block {
+            state: NodeState,
+            text: Text,
+        }
+
+        #[derive_commands]
+        impl Block {
+            fn new(t: &str) -> Self {
+                Block {
+                    state: NodeState::default(),
+                    text: Text::new(t).with_fixed_width(t.len() as u16),
+                }
+            }
+        }
+
+        impl ListItem for Block {}
+
+        impl Node for Block {
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.text, vp, Rect::new(0, 0, sz.w, sz.h))?;
+                let vp = self.text.vp();
+                l.size(self, vp.canvas(), vp.canvas())?;
+                Ok(())
+            }
+
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.text)
+            }
+        }
+
+        #[derive(StatefulNode)]
+        struct Root {
+            state: NodeState,
+            list: frame::Frame<List<Block>>,
+        }
+
+        #[derive_commands]
+        impl Root {
+            fn new() -> Self {
+                Root {
+                    state: NodeState::default(),
+                    list: frame::Frame::new(List::new(vec![Block::new("A"), Block::new("B")])),
+                }
+            }
+        }
+
+        impl Node for Root {
+            fn children(&mut self, f: &mut dyn FnMut(&mut dyn Node) -> Result<()>) -> Result<()> {
+                f(&mut self.list)
+            }
+
+            fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
+                l.fill(self, sz)?;
+                let vp = self.vp();
+                l.place(&mut self.list, vp, vp.view())?;
+                Ok(())
+            }
+        }
+
+        let size = Expanse::new(4, 3);
+        let (_, mut cr) = CanvasRender::create(size);
+        let mut canopy = Canopy::new();
+        let mut root = Root::new();
+
+        canopy.set_root_size(size, &mut root)?;
+        canopy.render(&mut cr, &mut root)?;
+
+        // Append a new item that will be outside the visible view.
+        root.list.child.append(Block::new("C"));
+        canopy.render(&mut cr, &mut root)?;
+
+        let idx = root.list.child.len() - 1;
+        let itm = &mut root.list.child.items[idx].itm;
+        assert!(itm.is_hidden());
+        itm.children(&mut |ch| {
+            assert!(ch.is_hidden());
+            Ok(())
+        })?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- ensure children of clipped list items are hidden
- regression test for hidden list item children

## Testing
- `cargo test -p canopy -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_685cba8727c08333b630a413e84b912e