### PR TITLE
Fix geometry error in todo example

### DIFF
--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -159,7 +159,8 @@ impl Node for Todo {
 
         let a = self.vp().screen_rect();
         if let Some(add) = &mut self.adder {
-            l.place(add, vp, Rect::new(a.tl.x + 2, a.tl.y + a.h / 2, a.w - 4, 3))?;
+            let w = a.w.saturating_sub(4);
+            l.place(add, vp, Rect::new(a.tl.x + 2, a.tl.y + a.h / 2, w, 3))?;
         }
         Ok(())
     }
@@ -242,3 +243,4 @@ pub fn main() -> Result<()> {
 
     Ok(())
 }
+


### PR DESCRIPTION
## Summary
- avoid u16 underflow in todo example when placing add item

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685ccebd6a4c8333ae20e602af406467