### PR TITLE
Fix todo example crash when adding items

### DIFF
--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -159,7 +159,14 @@ impl Node for Todo {
 
         let a = self.vp().screen_rect();
         if let Some(add) = &mut self.adder {
-            l.place(add, vp, Rect::new(a.tl.x + 2, a.tl.y + a.h / 2, a.w - 4, 3))?;
+            let w = a.w.saturating_sub(4);
+            if w >= 2 && a.h >= 3 {
+                l.place(
+                    add,
+                    vp,
+                    Rect::new(a.tl.x + 2, a.tl.y + a.h / 2, w, 3),
+                )?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- prevent zero-width frame placement in todo example

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685ccebd6a4c8333ae20e602af406467