### PR TITLE
Extend harness with timeout methods

### DIFF
--- a/canopy/src/tutils/harness.rs
+++ b/canopy/src/tutils/harness.rs
@@ -1,0 +1,102 @@
+use crate::{
+    backend::test::TestRender,
+    event::key,
+    geom::Expanse,
+    Node, Loader, Canopy, Result
+};
+use super::ttree;
+use std::time::{Duration, Instant};
+
+/// Run a function on our standard dummy app.
+pub fn run(func: impl FnOnce(&mut Canopy, TestRender, ttree::R) -> Result<()>) -> Result<()> {
+    let (_, tr) = TestRender::create();
+    let mut root = ttree::R::new();
+    let mut c = Canopy::new();
+
+    c.add_commands::<ttree::R>();
+    c.add_commands::<ttree::BaLa>();
+    c.add_commands::<ttree::BaLb>();
+    c.add_commands::<ttree::BbLa>();
+    c.add_commands::<ttree::BbLb>();
+    c.add_commands::<ttree::Ba>();
+    c.add_commands::<ttree::Bb>();
+
+    c.set_root_size(Expanse::new(100, 100), &mut root)?;
+    ttree::reset_state();
+    func(&mut c, tr, root)
+}
+
+/// A thin wrapper around [`Canopy`] that exposes a limited public API suitable
+/// for driving tests.
+pub struct Harness<'a> {
+    core: &'a mut Canopy,
+}
+
+impl<'a> Harness<'a> {
+    pub fn key<T>(&mut self, root: &mut dyn Node, k: T) -> Result<()>
+    where
+        T: Into<key::Key>,
+    {
+        self.core.key(root, k)
+    }
+
+    /// Version of [`key`] that fails the test if processing takes longer than
+    /// `timeout`.
+    pub fn key_timeout<T>(&mut self, root: &mut dyn Node, k: T, timeout: Duration) -> Result<()>
+    where
+        T: Into<key::Key>,
+    {
+        let start = Instant::now();
+        let ret = self.key(root, k);
+        if start.elapsed() > timeout {
+            panic!("key event timed out");
+        }
+        ret
+    }
+
+    pub fn render(&mut self, r: &mut TestRender, root: &mut dyn Node) -> Result<()> {
+        self.core.render(r, root)
+    }
+
+    /// Version of [`render`] that fails the test if processing takes longer than
+    /// `timeout`.
+    pub fn render_timeout(
+        &mut self,
+        r: &mut TestRender,
+        root: &mut dyn Node,
+        timeout: Duration,
+    ) -> Result<()> {
+        let start = Instant::now();
+        let ret = self.render(r, root);
+        if start.elapsed() > timeout {
+            panic!("render timed out");
+        }
+        ret
+    }
+
+    pub fn canopy(&mut self) -> &mut Canopy {
+        self.core
+    }
+}
+
+/// Run a function on a provided root node using the test render backend.
+///
+/// The root node must implement [`Loader`] so that command sets can be loaded
+/// for the test environment. The node is laid out with a default size before
+/// the supplied closure is executed.
+pub fn run_root<N>(
+    mut root: N,
+    func: impl FnOnce(&mut Harness<'_>, &mut TestRender, &mut N) -> Result<()>,
+) -> Result<()>
+where
+    N: Node + Loader,
+{
+    let (_, mut tr) = TestRender::create();
+    let mut c = Canopy::new();
+
+    <N as Loader>::load(&mut c);
+    c.set_root_size(Expanse::new(100, 100), &mut root)?;
+
+    let mut h = Harness { core: &mut c };
+    func(&mut h, &mut tr, &mut root)
+}

--- a/canopy/src/tutils/mod.rs
+++ b/canopy/src/tutils/mod.rs
@@ -1,10 +1,12 @@
 pub mod ttree;
+pub mod harness;
 pub use ttree::*;
+pub use harness::*;
 
 use crate::{self as canopy};
+#[cfg(test)]
+use crate::backend::test::TestRender;
 use crate::{
-    backend::test::TestRender,
-    event::key,
     geom::{Direction, Expanse, Rect},
     path::Path,
     widgets::list::ListItem,
@@ -39,70 +41,6 @@ impl TFixed {
 }
 
 impl ListItem for TFixed {}
-
-/// Run a function on our standard dummy app.
-pub fn run(func: impl FnOnce(&mut Canopy, TestRender, ttree::R) -> Result<()>) -> Result<()> {
-    let (_, tr) = TestRender::create();
-    let mut root = ttree::R::new();
-    let mut c = Canopy::new();
-
-    c.add_commands::<ttree::R>();
-    c.add_commands::<ttree::BaLa>();
-    c.add_commands::<ttree::BaLb>();
-    c.add_commands::<ttree::BbLa>();
-    c.add_commands::<ttree::BbLb>();
-    c.add_commands::<ttree::Ba>();
-    c.add_commands::<ttree::Bb>();
-
-    c.set_root_size(Expanse::new(100, 100), &mut root)?;
-    ttree::reset_state();
-    func(&mut c, tr, root)
-}
-
-/// A thin wrapper around [`Canopy`] that exposes a limited public API suitable
-/// for driving tests.
-pub struct Harness<'a> {
-    core: &'a mut Canopy,
-}
-
-impl<'a> Harness<'a> {
-    pub fn key<T>(&mut self, root: &mut dyn Node, k: T) -> Result<()>
-    where
-        T: Into<key::Key>,
-    {
-        self.core.key(root, k)
-    }
-
-    pub fn render(&mut self, r: &mut TestRender, root: &mut dyn Node) -> Result<()> {
-        self.core.render(r, root)
-    }
-
-    pub fn canopy(&mut self) -> &mut Canopy {
-        self.core
-    }
-}
-
-/// Run a function on a provided root node using the test render backend.
-///
-/// The root node must implement [`Loader`] so that command sets can be loaded
-/// for the test environment. The node is laid out with a default size before
-/// the supplied closure is executed.
-pub fn run_root<N>(
-    mut root: N,
-    func: impl FnOnce(&mut Harness<'_>, &mut TestRender, &mut N) -> Result<()>,
-) -> Result<()>
-where
-    N: Node + Loader,
-{
-    let (_, mut tr) = TestRender::create();
-    let mut c = Canopy::new();
-
-    <N as Loader>::load(&mut c);
-    c.set_root_size(Expanse::new(100, 100), &mut root)?;
-
-    let mut h = Harness { core: &mut c };
-    func(&mut h, &mut tr, &mut root)
-}
 
 pub struct DummyContext {}
 

--- a/examples/todo/tests/basic.rs
+++ b/examples/todo/tests/basic.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use canopy::tutils::run_root;
+use std::time::Duration;
 use todo::{bind_keys, open_store, style, Todo};
 
 #[test]
@@ -15,9 +16,18 @@ fn add_item_via_script() -> Result<()> {
     run_root(Todo::new()?, |h, tr, root| {
         style(h.canopy());
         bind_keys(h.canopy());
-        h.render(tr, root).expect("initial render");
-        h.key(root, 'a').expect("press a");
-        h.render(tr, root).expect("second render");
+        h.render_timeout(tr, root, Duration::from_secs(1))?;
+        h.key_timeout(root, 'a', Duration::from_secs(1))?;
+        h.render_timeout(tr, root, Duration::from_secs(1))?;
+        h.key_timeout(root, 'h', Duration::from_secs(1))?;
+        h.key_timeout(root, 'i', Duration::from_secs(1))?;
+        use canopy::event::key::KeyCode;
+        h.key_timeout(root, KeyCode::Enter, Duration::from_secs(1))?;
+        h.render_timeout(tr, root, Duration::from_secs(1))?;
+        assert_eq!(root.content.child.len(), 1);
+        let todos = todo::store::get().todos().unwrap();
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].item.trim(), "hi");
         Ok(())
     })?;
     Ok(())


### PR DESCRIPTION
## Summary
- move test harness pieces to a new `tutils::harness` module
- add timeout-aware `key_timeout` and `render_timeout` helpers
- update todo example test to use new helpers and verify item creation

## Testing
- `cargo test -p todo --test basic`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685ce2c965ec83338e1be3a8c0fa8c5c