### PR TITLE
Improve test harness and add failing render test

### DIFF
--- a/canopy/src/backend/test.rs
+++ b/canopy/src/backend/test.rs
@@ -19,6 +19,10 @@ impl TestBuf {
     pub fn is_empty(&self) -> bool {
         self.text.is_empty()
     }
+
+    pub fn contains(&self, s: &str) -> bool {
+        self.text.iter().any(|l| l.contains(s))
+    }
 }
 
 /// A render backend for testing, which logs render outcomes.
@@ -51,6 +55,10 @@ impl TestRender {
 
     pub fn buf_empty(&self) -> bool {
         self.text.lock().unwrap().text.is_empty()
+    }
+
+    pub fn contains_text(&self, txt: &str) -> bool {
+        self.text.lock().unwrap().contains(txt)
     }
 }
 

--- a/canopy/src/tutils/harness.rs
+++ b/canopy/src/tutils/harness.rs
@@ -79,8 +79,9 @@ impl<'a> Harness<'a> {
 /// The root node must implement [`Loader`] so that command sets can be loaded
 /// for the test environment. The node is laid out with a default size before
 /// the supplied closure is executed.
-pub fn run_root<N>(
+pub fn run_root_with_size<N>(
     mut root: N,
+    size: Expanse,
     func: impl FnOnce(&mut Harness<'_>, &mut TestRender, &mut N) -> Result<()>,
 ) -> Result<()>
 where
@@ -90,8 +91,18 @@ where
     let mut c = Canopy::new();
 
     <N as Loader>::load(&mut c);
-    c.set_root_size(Expanse::new(100, 100), &mut root)?;
+    c.set_root_size(size, &mut root)?;
 
     let mut h = Harness { core: &mut c };
     func(&mut h, &mut tr, &mut root)
+}
+
+pub fn run_root<N>(
+    root: N,
+    func: impl FnOnce(&mut Harness<'_>, &mut TestRender, &mut N) -> Result<()>,
+) -> Result<()>
+where
+    N: Node + Loader,
+{
+    run_root_with_size(root, Expanse::new(100, 100), func)
 }

--- a/examples/todo/tests/basic.rs
+++ b/examples/todo/tests/basic.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use canopy::tutils::run_root;
+use canopy::tutils::run_root_with_size;
 use std::time::Duration;
 use todo::{bind_keys, open_store, style, Todo};
 
@@ -31,4 +32,26 @@ fn add_item_via_script() -> Result<()> {
         Ok(())
     })?;
     Ok(())
+}
+
+#[test]
+#[should_panic]
+fn render_seeded_item() {
+    use canopy::geom::Expanse;
+    let path = std::env::temp_dir().join(format!(
+        "todo_test_seed_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    open_store(path.to_str().unwrap()).unwrap();
+    todo::store::get().add_todo("seeded").unwrap();
+    run_root_with_size(Todo::new().unwrap(), Expanse::new(20, 5), |h, tr, root| {
+        style(h.canopy());
+        bind_keys(h.canopy());
+        h.render_timeout(tr, root, Duration::from_secs(1)).unwrap();
+        assert!(tr.contains_text("seeded"));
+        Ok(())
+    }).unwrap();
 }


### PR DESCRIPTION
## Summary
- extend test harness with `run_root_with_size`
- add helper on `TestRender` to search render buffer
- reproduce todo rendering bug with a new test

## Testing
- `cargo test --locked --all`

------
https://chatgpt.com/codex/tasks/task_e_685cf04a43d883339f96743b8560bebb