### PR TITLE
Fix todo focus bug

### DIFF
--- a/examples/todo/src/lib.rs
+++ b/examples/todo/src/lib.rs
@@ -117,18 +117,24 @@ impl Todo {
     }
 
     #[command]
-    pub fn accept_add(&mut self, _: &mut dyn Context) -> canopy::Result<()> {
-        if let Some(adder) = &mut self.adder {
-            let item = store::get().add_todo(&adder.child.text()).unwrap();
-            self.content.child.append(TodoItem::new(item));
-            self.adder = None;
+    pub fn accept_add(&mut self, c: &mut dyn Context) -> canopy::Result<()> {
+        if let Some(adder) = self.adder.take() {
+            let value = adder.child.textbuf.value;
+            if !value.is_empty() {
+                let item = store::get().add_todo(&value).unwrap();
+                self.content.child.append(TodoItem::new(item));
+            }
         }
+        c.taint_tree(self);
+        c.focus_first(self);
         Ok(())
     }
 
     #[command]
-    pub fn cancel_add(&mut self, _: &mut dyn Context) -> canopy::Result<()> {
+    pub fn cancel_add(&mut self, c: &mut dyn Context) -> canopy::Result<()> {
         self.adder = None;
+        c.taint_tree(self);
+        c.focus_first(self);
         Ok(())
     }
 

--- a/examples/todo/tests/hang.rs
+++ b/examples/todo/tests/hang.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use todo::open_store;
 
 #[test]
-#[should_panic]
 fn add_item_via_pty() {
     let db_path = std::env::temp_dir().join(format!(
         "todo_test_pty_{}.db",
@@ -19,7 +18,7 @@ fn add_item_via_pty() {
 
     app.send("a").unwrap();
     app.send("hi").unwrap();
-    app.send_line("").unwrap();
+    app.send("\r").unwrap();
     app.send("q").unwrap();
 
     app.wait_eof(Duration::from_secs(2)).unwrap();


### PR DESCRIPTION
## Summary
- fix focus after adding a todo item so quitting works
- update PTY test to send carriage return

## Testing
- `cargo test --test basic --test hang -p todo`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685d19bcfb788333a948bb8a2405ab37