### PR TITLE
Fix deletion edge case and extend tests

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -120,7 +120,11 @@ where
     pub fn delete_item(&mut self, core: &mut dyn Context, offset: usize) -> Option<N> {
         if !self.is_empty() && offset < self.len() {
             let itm = self.items.remove(offset);
-            if offset <= self.offset {
+            if self.is_empty() {
+                self.offset = 0;
+                core.taint(self);
+            } else if offset <= self.offset {
+                self.offset = self.offset.min(self.len() - 1);
                 self.select_prev(core);
             }
             Some(itm.itm)


### PR DESCRIPTION
## Summary
- fix panic when deleting the last list item
- add PTY-based regression test (ignored) and harness test for adding and removing items

## Testing
- `cargo test --workspace --tests`

------
https://chatgpt.com/codex/tasks/task_e_685d37ed8bdc8333976b3c9976eb47c2