### PR TITLE
Extend pty test & handle empty list

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -131,6 +131,9 @@ where
 
     /// Make sure the selected item is within the view after a change.
     fn ensure_selected_in_view(&mut self, c: &mut dyn Context) -> bool {
+        if self.is_empty() {
+            return false;
+        }
         let virt = self.items[self.offset].virt;
         let view = self.vp().view();
         if let Some(v) = virt.vextent().intersection(&view.vextent()) {


### PR DESCRIPTION
## Summary
- make `List::ensure_selected_in_view` tolerant of empty lists
- extend `add_item_via_pty` integration test to add and remove several items

## Testing
- `cargo test -p todo add_item_via_pty -- --exact --nocapture`
- `cargo test --workspace -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_685d3c18e43883339f68d68f867c96f5