### PR TITLE
Fix list repaint on delete and extend PTY tests

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -123,6 +123,7 @@ where
             if offset <= self.offset {
                 self.select_prev(core);
             }
+            core.taint(self);
             Some(itm.itm)
         } else {
             None
@@ -131,6 +132,9 @@ where
 
     /// Make sure the selected item is within the view after a change.
     fn ensure_selected_in_view(&mut self, c: &mut dyn Context) -> bool {
+        if self.is_empty() {
+            return false;
+        }
         let virt = self.items[self.offset].virt;
         let view = self.vp().view();
         if let Some(v) = virt.vextent().intersection(&view.vextent()) {

--- a/examples/todo/tests/basic.rs
+++ b/examples/todo/tests/basic.rs
@@ -96,10 +96,109 @@ fn add_item_via_pty() {
     let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
     app.expect("todo", Duration::from_millis(100)).ok();
 
-    app.send("a").unwrap();
-    app.send("hi").unwrap();
-    app.send("\r").unwrap();
-    app.send("q").unwrap();
+    fn add(app: &mut canopy::tutils::PtyApp, text: &str) {
+        app.send("a").unwrap();
+        app.send(text).unwrap();
+        app.send("\r").unwrap();
+        app.expect(text, Duration::from_millis(200)).unwrap();
+    }
 
+    fn del(app: &mut canopy::tutils::PtyApp, expected_next: Option<&str>) {
+        app.send("g").unwrap();
+        app.send("d").unwrap();
+        if let Some(txt) = expected_next {
+            app.expect(txt, Duration::from_millis(200)).unwrap();
+        }
+    }
+
+    add(&mut app, "item_one");
+    add(&mut app, "item_two");
+    add(&mut app, "item_three");
+
+    del(&mut app, Some("item_two"));
+    del(&mut app, Some("item_three"));
+    del(&mut app, None);
+
+    // App should still respond after deleting the last item
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn delete_reverse_via_pty() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_rev_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    fn add(app: &mut canopy::tutils::PtyApp, text: &str) {
+        app.send("a").unwrap();
+        app.send(text).unwrap();
+        app.send("\r").unwrap();
+        app.expect(text, Duration::from_millis(200)).unwrap();
+    }
+
+    fn del(app: &mut canopy::tutils::PtyApp, expected_next: Option<&str>) {
+        app.send("g").unwrap();
+        app.send("d").unwrap();
+        if let Some(txt) = expected_next {
+            app.expect(txt, Duration::from_millis(200)).unwrap();
+        }
+    }
+
+    add(&mut app, "one");
+    add(&mut app, "two");
+    add(&mut app, "three");
+
+    app.send("j").unwrap();
+    app.send("j").unwrap();
+    del(&mut app, Some("two"));
+    del(&mut app, Some("one"));
+    del(&mut app, None);
+
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn single_item_add_remove() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_single_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    fn add(app: &mut canopy::tutils::PtyApp, text: &str) {
+        app.send("a").unwrap();
+        app.send(text).unwrap();
+        app.send("\r").unwrap();
+        app.expect(text, Duration::from_millis(200)).unwrap();
+    }
+
+    fn del(app: &mut canopy::tutils::PtyApp, expected_next: Option<&str>) {
+        app.send("g").unwrap();
+        app.send("d").unwrap();
+        if let Some(txt) = expected_next {
+            app.expect(txt, Duration::from_millis(200)).unwrap();
+        }
+    }
+
+    add(&mut app, "solo");
+    del(&mut app, None);
+
+    app.send("q").unwrap();
     app.wait_eof(Duration::from_secs(2)).unwrap();
 }


### PR DESCRIPTION
## Summary
- ensure list is repainted when an item is deleted
- add PTY tests for reverse deletion order and single-item removal

## Testing
- `cargo test --workspace -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_685d3c18e43883339f68d68f867c96f5