### PR TITLE
Fix list repaint on delete and extend PTY tests

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -88,7 +88,11 @@ where
 
     /// Append an item to the end of the list.
     pub fn append(&mut self, itm: N) {
+        let was_empty = self.is_empty();
         self.items.insert(self.len(), Item::new(itm));
+        if was_empty {
+            self.items[0].set_selected(true);
+        }
     }
 
     /// The current selected item, if any
@@ -118,11 +122,21 @@ where
 
     /// Move selection to the next item in the list, if possible.
     pub fn delete_item(&mut self, core: &mut dyn Context, offset: usize) -> Option<N> {
-        if !self.is_empty() && offset < self.len() {
+        if offset < self.len() {
+            self.items[offset].set_selected(false);
             let itm = self.items.remove(offset);
-            if offset <= self.offset {
-                self.select_prev(core);
+            if self.items.is_empty() {
+                self.offset = 0;
+            } else {
+                if self.offset >= offset && self.offset > 0 {
+                    self.offset -= 1;
+                } else if self.offset >= self.len() {
+                    self.offset = self.len() - 1;
+                }
+                self.items[self.offset].set_selected(true);
+                self.ensure_selected_in_view(core);
             }
+            core.taint(self);
             Some(itm.itm)
         } else {
             None
@@ -131,6 +145,9 @@ where
 
     /// Make sure the selected item is within the view after a change.
     fn ensure_selected_in_view(&mut self, c: &mut dyn Context) -> bool {
+        if self.is_empty() {
+            return false;
+        }
         let virt = self.items[self.offset].virt;
         let view = self.vp().view();
         if let Some(v) = virt.vextent().intersection(&view.vextent()) {

--- a/examples/todo/tests/basic.rs
+++ b/examples/todo/tests/basic.rs
@@ -96,10 +96,109 @@ fn add_item_via_pty() {
     let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
     app.expect("todo", Duration::from_millis(100)).ok();
 
-    app.send("a").unwrap();
-    app.send("hi").unwrap();
-    app.send("\r").unwrap();
-    app.send("q").unwrap();
+    fn add(app: &mut canopy::tutils::PtyApp, text: &str) {
+        app.send("a").unwrap();
+        app.send(text).unwrap();
+        app.send("\r").unwrap();
+        app.expect(text, Duration::from_millis(200)).unwrap();
+    }
 
+    fn del(app: &mut canopy::tutils::PtyApp, expected_next: Option<&str>) {
+        app.send("g").unwrap();
+        app.send("d").unwrap();
+        if let Some(txt) = expected_next {
+            app.expect(txt, Duration::from_millis(200)).unwrap();
+        }
+    }
+
+    add(&mut app, "item_one");
+    add(&mut app, "item_two");
+    add(&mut app, "item_three");
+
+    del(&mut app, Some("item_two"));
+    del(&mut app, Some("item_three"));
+    del(&mut app, None);
+
+    // App should still respond after deleting the last item
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn delete_reverse_via_pty() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_rev_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    fn add(app: &mut canopy::tutils::PtyApp, text: &str) {
+        app.send("a").unwrap();
+        app.send(text).unwrap();
+        app.send("\r").unwrap();
+        app.expect(text, Duration::from_millis(200)).unwrap();
+    }
+
+    fn del(app: &mut canopy::tutils::PtyApp, expected_next: Option<&str>) {
+        app.send("g").unwrap();
+        app.send("d").unwrap();
+        if let Some(txt) = expected_next {
+            app.expect(txt, Duration::from_millis(200)).unwrap();
+        }
+    }
+
+    add(&mut app, "one");
+    add(&mut app, "two");
+    add(&mut app, "three");
+
+    app.send("j").unwrap();
+    app.send("j").unwrap();
+    del(&mut app, Some("two"));
+    del(&mut app, Some("one"));
+    del(&mut app, None);
+
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn single_item_add_remove() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_single_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    fn add(app: &mut canopy::tutils::PtyApp, text: &str) {
+        app.send("a").unwrap();
+        app.send(text).unwrap();
+        app.send("\r").unwrap();
+        app.expect(text, Duration::from_millis(200)).unwrap();
+    }
+
+    fn del(app: &mut canopy::tutils::PtyApp, expected_next: Option<&str>) {
+        app.send("g").unwrap();
+        app.send("d").unwrap();
+        if let Some(txt) = expected_next {
+            app.expect(txt, Duration::from_millis(200)).unwrap();
+        }
+    }
+
+    add(&mut app, "solo");
+    del(&mut app, None);
+
+    app.send("q").unwrap();
     app.wait_eof(Duration::from_secs(2)).unwrap();
 }


### PR DESCRIPTION
## Summary
- ensure list is repainted when an item is deleted
- add PTY tests for reverse deletion order and single-item removal
- fix crash when deleting last selected item by updating list offset

## Testing
- `cargo test --workspace -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_685d3c18e43883339f68d68f867c96f5