### PR TITLE
Fix list repaint and PTY tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,6 +1142,7 @@ dependencies = [
  "anyhow",
  "canopy",
  "clap",
+ "expectrl",
  "rusqlite",
  "tracing",
 ]

--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -118,19 +118,39 @@ where
 
     /// Move selection to the next item in the list, if possible.
     pub fn delete_item(&mut self, core: &mut dyn Context, offset: usize) -> Option<N> {
-        if !self.is_empty() && offset < self.len() {
-            let itm = self.items.remove(offset);
-            if offset <= self.offset {
-                self.select_prev(core);
-            }
-            Some(itm.itm)
-        } else {
-            None
+        if offset >= self.items.len() {
+            return None;
         }
+
+        // Clear the previous selection while indices are valid.
+        if let Some(itm) = self.items.get_mut(self.offset) {
+            itm.set_selected(false);
+        }
+
+        let itm = self.items.remove(offset);
+
+        if self.items.is_empty() {
+            self.offset = 0;
+        } else {
+            if self.offset > offset {
+                self.offset -= 1;
+            } else if self.offset >= self.items.len() {
+                self.offset = self.items.len() - 1;
+            }
+            if let Some(itm) = self.items.get_mut(self.offset) {
+                itm.set_selected(true);
+            }
+        }
+
+        core.taint_tree(self);
+        Some(itm.itm)
     }
 
     /// Make sure the selected item is within the view after a change.
     fn ensure_selected_in_view(&mut self, c: &mut dyn Context) -> bool {
+        if self.is_empty() {
+            return false;
+        }
         let virt = self.items[self.offset].virt;
         let view = self.vp().view();
         if let Some(v) = virt.vextent().intersection(&view.vextent()) {

--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -9,3 +9,6 @@ canopy = { path = "../../canopy" }
 clap = { version = "4.5.40", features = ["derive"] }
 rusqlite = "0.36.0"
 tracing = "0.1.41"
+
+[dev-dependencies]
+expectrl = "0.7.1"

--- a/examples/todo/tests/basic.rs
+++ b/examples/todo/tests/basic.rs
@@ -3,6 +3,23 @@ use canopy::tutils::{run_root, run_root_with_size, spawn_workspace_bin};
 use std::time::Duration;
 use todo::{bind_keys, open_store, style, Todo};
 
+fn add(app: &mut canopy::tutils::PtyApp, text: &str) {
+    app.send("a").unwrap();
+    app.send(text).unwrap();
+    app.send("\r").unwrap();
+    app.expect(text, Duration::from_millis(200)).unwrap();
+    app.expect("\x1b[38;", Duration::from_millis(200)).unwrap();
+}
+
+fn del(app: &mut canopy::tutils::PtyApp, expected_next: Option<&str>) {
+    app.send("g").unwrap();
+    app.send("d").unwrap();
+    if let Some(txt) = expected_next {
+        app.expect(txt, Duration::from_millis(200)).unwrap();
+        app.expect("\x1b[38;", Duration::from_millis(200)).unwrap();
+    }
+}
+
 #[test]
 fn add_item_via_script() -> Result<()> {
     let path = std::env::temp_dir().join(format!(
@@ -96,10 +113,91 @@ fn add_item_via_pty() {
     let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
     app.expect("todo", Duration::from_millis(100)).ok();
 
-    app.send("a").unwrap();
-    app.send("hi").unwrap();
-    app.send("\r").unwrap();
-    app.send("q").unwrap();
+    add(&mut app, "item_one");
+    add(&mut app, "item_two");
+    add(&mut app, "item_three");
 
+    del(&mut app, Some("item_two"));
+    del(&mut app, Some("item_three"));
+    del(&mut app, None);
+
+    // App should still respond after deleting the last item
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn delete_reverse_via_pty() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_rev_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    add(&mut app, "one");
+    add(&mut app, "two");
+    add(&mut app, "three");
+
+    app.send("j").unwrap();
+    app.send("j").unwrap();
+    del(&mut app, Some("two"));
+    del(&mut app, Some("one"));
+    del(&mut app, None);
+
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn single_item_add_remove() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_single_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    add(&mut app, "solo");
+    del(&mut app, None);
+
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn delete_after_moving_focus() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_move_del_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    add(&mut app, "first");
+    add(&mut app, "second");
+
+    app.send("j").unwrap();
+    app.expect("second", Duration::from_millis(200)).unwrap();
+    app.send("d").unwrap();
+    app.expect("first", Duration::from_millis(200)).unwrap();
+    app.expect("\x1b[38;", Duration::from_millis(200)).unwrap();
+
+    app.send("q").unwrap();
     app.wait_eof(Duration::from_secs(2)).unwrap();
 }


### PR DESCRIPTION
## Summary
- ensure list selection logic handles deletes correctly
- repaint list subtree when removing items
- add expectrl dependency for todo tests
- extend PTY tests to check focus highlight and deletion edge cases

## Testing
- `cargo test --workspace -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_685d3c18e43883339f68d68f867c96f5