### PR TITLE
Fix list repaint and PTY tests

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -89,6 +89,10 @@ where
     /// Append an item to the end of the list.
     pub fn append(&mut self, itm: N) {
         self.items.insert(self.len(), Item::new(itm));
+        if self.items.len() == 1 {
+            self.offset = 0;
+            self.items[0].set_selected(true);
+        }
     }
 
     /// The current selected item, if any
@@ -118,19 +122,39 @@ where
 
     /// Move selection to the next item in the list, if possible.
     pub fn delete_item(&mut self, core: &mut dyn Context, offset: usize) -> Option<N> {
-        if !self.is_empty() && offset < self.len() {
-            let itm = self.items.remove(offset);
-            if offset <= self.offset {
-                self.select_prev(core);
-            }
-            Some(itm.itm)
-        } else {
-            None
+        if offset >= self.items.len() {
+            return None;
         }
+
+        // Clear the previous selection while indices are valid.
+        if let Some(itm) = self.items.get_mut(self.offset) {
+            itm.set_selected(false);
+        }
+
+        let itm = self.items.remove(offset);
+
+        if self.items.is_empty() {
+            self.offset = 0;
+        } else {
+            if self.offset > offset {
+                self.offset -= 1;
+            } else if self.offset >= self.items.len() {
+                self.offset = self.items.len() - 1;
+            }
+            if let Some(itm) = self.items.get_mut(self.offset) {
+                itm.set_selected(true);
+            }
+        }
+
+        core.taint_tree(self);
+        Some(itm.itm)
     }
 
     /// Make sure the selected item is within the view after a change.
     fn ensure_selected_in_view(&mut self, c: &mut dyn Context) -> bool {
+        if self.is_empty() {
+            return false;
+        }
         let virt = self.items[self.offset].virt;
         let view = self.vp().view();
         if let Some(v) = virt.vextent().intersection(&view.vextent()) {

--- a/examples/todo/tests/basic.rs
+++ b/examples/todo/tests/basic.rs
@@ -3,6 +3,33 @@ use canopy::tutils::{run_root, run_root_with_size, spawn_workspace_bin};
 use std::time::Duration;
 use todo::{bind_keys, open_store, style, Todo};
 
+fn expect_highlight(app: &mut canopy::tutils::PtyApp, text: &str) {
+    app.expect(text, Duration::from_millis(200)).unwrap();
+    app.expect("\x1b[38;", Duration::from_millis(200)).unwrap();
+}
+
+fn add(app: &mut canopy::tutils::PtyApp, text: &str) {
+    app.send("a").unwrap();
+    app.send(text).unwrap();
+    app.send("\r").unwrap();
+    expect_highlight(app, text);
+}
+
+fn del_first(app: &mut canopy::tutils::PtyApp, expected_next: Option<&str>) {
+    app.send("g").unwrap();
+    app.send("d").unwrap();
+    if let Some(txt) = expected_next {
+        expect_highlight(app, txt);
+    }
+}
+
+fn del_no_nav(app: &mut canopy::tutils::PtyApp, expected_next: Option<&str>) {
+    app.send("d").unwrap();
+    if let Some(txt) = expected_next {
+        expect_highlight(app, txt);
+    }
+}
+
 #[test]
 fn add_item_via_script() -> Result<()> {
     let path = std::env::temp_dir().join(format!(
@@ -96,10 +123,142 @@ fn add_item_via_pty() {
     let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
     app.expect("todo", Duration::from_millis(100)).ok();
 
-    app.send("a").unwrap();
-    app.send("hi").unwrap();
-    app.send("\r").unwrap();
-    app.send("q").unwrap();
+    add(&mut app, "item_one");
+    add(&mut app, "item_two");
+    add(&mut app, "item_three");
 
+    del_first(&mut app, Some("item_two"));
+    del_first(&mut app, Some("item_three"));
+    del_first(&mut app, None);
+
+    // App should still respond after deleting the last item
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn delete_reverse_via_pty() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_rev_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    add(&mut app, "one");
+    add(&mut app, "two");
+    add(&mut app, "three");
+
+    app.send("j").unwrap();
+    app.send("j").unwrap();
+    del_first(&mut app, Some("two"));
+    del_first(&mut app, Some("one"));
+    del_first(&mut app, None);
+
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn single_item_add_remove() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_single_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    add(&mut app, "solo");
+    del_first(&mut app, None);
+
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn delete_after_moving_focus() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_move_del_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    add(&mut app, "first");
+    add(&mut app, "second");
+
+    app.send("j").unwrap();
+    app.expect("second", Duration::from_millis(200)).unwrap();
+    app.send("d").unwrap();
+    expect_highlight(&mut app, "first");
+
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn delete_first_without_nav() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_del_first_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    add(&mut app, "a1");
+    add(&mut app, "a2");
+    add(&mut app, "a3");
+
+    del_no_nav(&mut app, Some("a2"));
+    del_no_nav(&mut app, Some("a3"));
+
+    app.send("q").unwrap();
+    app.wait_eof(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
+fn focus_moves_with_navigation() {
+    let db_path = std::env::temp_dir().join(format!(
+        "todo_test_nav_{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    ));
+    open_store(db_path.to_str().unwrap()).unwrap();
+
+    let mut app = spawn_workspace_bin("todo", &[db_path.to_str().unwrap()]).unwrap();
+    app.expect("todo", Duration::from_millis(100)).ok();
+
+    add(&mut app, "one");
+    add(&mut app, "two");
+
+    app.send("j").unwrap();
+    expect_highlight(&mut app, "two");
+
+    app.send("k").unwrap();
+    expect_highlight(&mut app, "one");
+
+    app.send("q").unwrap();
     app.wait_eof(Duration::from_secs(2)).unwrap();
 }


### PR DESCRIPTION
## Summary
- select first item when appending to an empty list
- remove redundant expectrl dev dependency from todo example
- extend PTY tests and helpers for focus detection and deletion edge cases

## Testing
- `cargo test --workspace -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_685d3c18e43883339f68d68f867c96f5