### PR TITLE
Fix list deletion refresh and tidy todo tests

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -146,6 +146,7 @@ where
             }
         }
 
+        self.ensure_selected_in_view(core);
         core.taint_tree(self);
         Some(itm.itm)
     }


### PR DESCRIPTION
## Summary
- ensure selected item stays visible when deleting from a list
- refactor todo example tests to remove duplication
- add regression test covering deletion of middle item

## Testing
- `cargo test --manifest-path examples/todo/Cargo.toml -- --nocapture`
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685dd187bc8483338ba06c7d82efbad9