### PR TITLE
Fix todo list deletion rendering

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -146,6 +146,7 @@ where
             }
         }
 
+        self.ensure_selected_in_view(core);
         core.taint_tree(self);
         Some(itm.itm)
     }


### PR DESCRIPTION
## Summary
- ensure list scrolling is correct after deleting an item
- refactor todo example tests to use a helper
- add regression test covering deletion of a middle item

## Testing
- `cargo test --workspace -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_685dd187bc8483338ba06c7d82efbad9