### PR TITLE
Fix list delete bug and streamline todo tests

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -146,7 +146,11 @@ where
             }
         }
 
+        let scrolled = self.ensure_selected_in_view(core);
         core.taint_tree(self);
+        if scrolled {
+            core.taint(self);
+        }
         Some(itm.itm)
     }
 


### PR DESCRIPTION
## Summary
- ensure list scrolls after deleting items
- refactor todo example tests for clarity
- add regression test for deleting middle item

## Testing
- `cargo test -p todo -- --test-threads=1`
- `cargo test --all -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_685dd187bc8483338ba06c7d82efbad9