### PR TITLE
Fix list deletion rendering and tests

### DIFF
--- a/canopy/src/widgets/list.rs
+++ b/canopy/src/widgets/list.rs
@@ -126,6 +126,10 @@ where
             return None;
         }
 
+        // Track the first visible item before we mutate the list so we can
+        // decide if scrolling is necessary afterwards.
+        let view_start = self.view_range().0;
+
         // Clear the previous selection while indices are valid.
         if let Some(itm) = self.items.get_mut(self.offset) {
             itm.set_selected(false);
@@ -143,6 +147,13 @@ where
             }
             if let Some(itm) = self.items.get_mut(self.offset) {
                 itm.set_selected(true);
+            }
+            // If the deleted item was below the view, we may need to adjust the
+            // scroll position so the newly selected item remains visible. If it
+            // was above the top of the view, the remaining items will slide up
+            // naturally when we next layout, so skip the scroll adjustment.
+            if offset > view_start && self.ensure_selected_in_view(core) {
+                core.taint(self);
             }
         }
 


### PR DESCRIPTION
## Summary
- fix scroll position when deleting an item so remaining items stay visible
- add regression test for deleting first of two items
- keep todo tests simple with new helpers

## Testing
- `cargo test --test basic --manifest-path examples/todo/Cargo.toml -- --nocapture`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685dd187bc8483338ba06c7d82efbad9