### PR TITLE
Implement TermBuf::render and improve diff

### DIFF
--- a/canopy/src/termbuffer.rs
+++ b/canopy/src/termbuffer.rs
@@ -106,9 +106,104 @@ impl TermBuf {
     }
 }
 
+impl TermBuf {
+    /// Diff this terminal buffer against a previous state, emitting changes
+    /// to the provided render backend.
+    pub fn diff<R: crate::render::RenderBackend>(
+        &self,
+        prev: &TermBuf,
+        backend: &mut R,
+    ) -> crate::Result<()> {
+        if self.size != prev.size {
+            return self.render(backend);
+        }
+        for y in 0..self.size.h {
+            let mut x = 0;
+            while x < self.size.w {
+                let idx = y as usize * self.size.w as usize + x as usize;
+                let cell = &self.cells[idx];
+                let same = if y < prev.size.h && x < prev.size.w {
+                    let pidx = y as usize * prev.size.w as usize + x as usize;
+                    prev.cells[pidx] == *cell
+                } else {
+                    false
+                };
+                if same {
+                    x += 1;
+                    continue;
+                }
+
+                let style = cell.style.clone();
+                let start_x = x;
+                let mut text = String::new();
+                while x < self.size.w {
+                    let idx2 = y as usize * self.size.w as usize + x as usize;
+                    let ccell = &self.cells[idx2];
+                    let same = if y < prev.size.h && x < prev.size.w {
+                        let pidx2 = y as usize * prev.size.w as usize + x as usize;
+                        prev.cells[pidx2] == *ccell
+                    } else {
+                        false
+                    };
+                    if !same && ccell.style == style {
+                        text.push(ccell.ch);
+                        x += 1;
+                    } else {
+                        break;
+                    }
+                }
+                backend.style(style)?;
+                backend.text(
+                    Point {
+                        x: start_x as u16,
+                        y,
+                    },
+                    &text,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Render this terminal buffer in full using the provided backend,
+    /// batching runs of text with the same style.
+    pub fn render<R: crate::render::RenderBackend>(&self, backend: &mut R) -> crate::Result<()> {
+        for y in 0..self.size.h {
+            let mut x = 0;
+            while x < self.size.w {
+                let idx = y as usize * self.size.w as usize + x as usize;
+                let cell = &self.cells[idx];
+                let style = cell.style.clone();
+                let start_x = x;
+                let mut text = String::new();
+                while x < self.size.w {
+                    let idx2 = y as usize * self.size.w as usize + x as usize;
+                    let ccell = &self.cells[idx2];
+                    if ccell.style == style {
+                        text.push(ccell.ch);
+                        x += 1;
+                    } else {
+                        break;
+                    }
+                }
+                backend.style(style)?;
+                backend.text(
+                    Point {
+                        x: start_x as u16,
+                        y,
+                    },
+                    &text,
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::render::RenderBackend;
     use crate::style::{AttrSet, Color};
 
     fn def_style() -> Style {
@@ -145,5 +240,123 @@ mod tests {
         assert_eq!(tb.get((0, 0).into()).unwrap().ch, '#');
         assert_eq!(tb.get((1, 1).into()).unwrap().ch, ' ');
         assert_eq!(tb.get((3, 3).into()).unwrap().ch, '#');
+    }
+
+    struct RecBackend {
+        ops: Vec<String>,
+    }
+
+    impl RecBackend {
+        fn new() -> Self {
+            RecBackend { ops: Vec::new() }
+        }
+    }
+
+    impl RenderBackend for RecBackend {
+        fn style(&mut self, s: Style) -> crate::Result<()> {
+            self.ops.push(format!("style {:?}", s));
+            Ok(())
+        }
+
+        fn text(&mut self, loc: Point, txt: &str) -> crate::Result<()> {
+            self.ops.push(format!("text {} {} {}", loc.x, loc.y, txt));
+            Ok(())
+        }
+
+        fn flush(&mut self) -> crate::Result<()> {
+            Ok(())
+        }
+
+        fn exit(&mut self, _code: i32) -> ! {
+            unreachable!()
+        }
+
+        fn reset(&mut self) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn diff_no_change() {
+        let style = def_style();
+        let tb1 = TermBuf::new(Expanse::new(3, 1), ' ', style.clone());
+        let tb2 = TermBuf::new(Expanse::new(3, 1), ' ', style.clone());
+        let mut be = RecBackend::new();
+        tb2.diff(&tb1, &mut be).unwrap();
+        assert!(be.ops.is_empty());
+    }
+
+    #[test]
+    fn diff_single_run() {
+        let style = def_style();
+        let prev = TermBuf::new(Expanse::new(3, 1), ' ', style.clone());
+        let mut cur = TermBuf::new(Expanse::new(3, 1), ' ', style.clone());
+        cur.text(style.clone(), Line::new(0, 0, 3), "ab");
+        let mut be = RecBackend::new();
+        cur.diff(&prev, &mut be).unwrap();
+        assert_eq!(be.ops.len(), 2);
+        assert_eq!(be.ops[0], format!("style {:?}", style));
+        assert_eq!(be.ops[1], "text 0 0 ab");
+    }
+
+    #[test]
+    fn diff_style_changes() {
+        let style1 = def_style();
+        let mut style2 = style1.clone();
+        style2.fg = Color::Red;
+
+        let prev = TermBuf::new(Expanse::new(2, 1), ' ', style1.clone());
+        let mut cur = TermBuf::new(Expanse::new(2, 1), ' ', style1.clone());
+        cur.fill(style2.clone(), Rect::new(0, 0, 1, 1), 'a');
+        cur.fill(style1.clone(), Rect::new(1, 0, 1, 1), 'b');
+
+        let mut be = RecBackend::new();
+        cur.diff(&prev, &mut be).unwrap();
+
+        assert_eq!(be.ops.len(), 4);
+        assert_eq!(be.ops[0], format!("style {:?}", style2));
+        assert_eq!(be.ops[1], "text 0 0 a");
+        assert_eq!(be.ops[2], format!("style {:?}", style1));
+        assert_eq!(be.ops[3], "text 1 0 b");
+    }
+
+    #[test]
+    fn diff_multi_line() {
+        let style = def_style();
+        let prev = TermBuf::new(Expanse::new(3, 2), ' ', style.clone());
+        let mut cur = TermBuf::new(Expanse::new(3, 2), ' ', style.clone());
+        cur.fill(style.clone(), Rect::new(0, 1, 2, 1), 'x');
+        let mut be = RecBackend::new();
+        cur.diff(&prev, &mut be).unwrap();
+        assert_eq!(be.ops.len(), 2);
+        assert_eq!(be.ops[0], format!("style {:?}", style));
+        assert_eq!(be.ops[1], "text 0 1 xx");
+    }
+
+    #[test]
+    fn render_whole_buffer() {
+        let style = def_style();
+        let mut tb = TermBuf::new(Expanse::new(3, 1), ' ', style.clone());
+        tb.text(style.clone(), Line::new(0, 0, 3), "ab");
+        let mut be = RecBackend::new();
+        tb.render(&mut be).unwrap();
+        assert_eq!(
+            be.ops,
+            vec![format!("style {:?}", style), "text 0 0 ab ".to_string(),]
+        );
+    }
+
+    #[test]
+    fn diff_size_change_rerender() {
+        let style = def_style();
+        let prev = TermBuf::new(Expanse::new(2, 1), ' ', style.clone());
+        let mut cur = TermBuf::new(Expanse::new(3, 1), ' ', style.clone());
+        cur.text(style.clone(), Line::new(0, 0, 3), "abc");
+        let mut be = RecBackend::new();
+        cur.diff(&prev, &mut be).unwrap();
+        assert_eq!(
+            be.ops,
+            vec![format!("style {:?}", style), "text 0 0 abc".to_string(),]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add `TermBuf::render` for full-buffer rendering with style batching
- call `render` from `diff` if buffer sizes differ
- extend tests with render scenarios and size-change behavior

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685e0faadd64833388b376be73c09b6e