### PR TITLE
Fix focus navigation strategy

### DIFF
--- a/crates/canopy/src/canopy.rs
+++ b/crates/canopy/src/canopy.rs
@@ -105,22 +105,32 @@ impl Context for Canopy {
     fn focus_dir(&mut self, root: &mut dyn Node, dir: Direction) {
         use crate::focus_navigation::{collect_focusable_nodes, find_focus_target};
 
-        // Collect all focusable nodes
-        if let Ok((focusable_nodes, Some((current_id, current_rect)))) =
-            collect_focusable_nodes(self, root)
-        {
-            if let Some(target_id) =
-                find_focus_target(current_rect, dir, &focusable_nodes, &current_id)
-            {
-                // Set focus on the target
-                walk_to_root(root, &target_id, &mut |node| {
-                    if node.id() == target_id && node.accept_focus() {
-                        self.set_focus(node);
-                    }
-                    Ok(())
-                })
-                .unwrap();
+        match collect_focusable_nodes(self, root) {
+            Ok((focusable_nodes, Some((current_id, current_rect)))) => {
+                if let Some(target_id) =
+                    find_focus_target(current_rect, dir, &focusable_nodes, &current_id)
+                {
+                    walk_to_root(root, &target_id, &mut |node| {
+                        if node.id() == target_id && node.accept_focus() {
+                            self.set_focus(node);
+                        }
+                        Ok(())
+                    })
+                    .unwrap();
+                }
             }
+            Ok((focusable_nodes, None)) => {
+                if let Some(first) = focusable_nodes.first() {
+                    walk_to_root(root, &first.id, &mut |node| {
+                        if node.id() == first.id && node.accept_focus() {
+                            self.set_focus(node);
+                        }
+                        Ok(())
+                    })
+                    .unwrap();
+                }
+            }
+            Err(_) => {}
         }
     }
 

--- a/crates/canopy/src/canopy.rs
+++ b/crates/canopy/src/canopy.rs
@@ -103,29 +103,23 @@ impl Context for Canopy {
 
     /// Move focus in a specified direction within the subtree at root.
     fn focus_dir(&mut self, root: &mut dyn Node, dir: Direction) {
-        use crate::focus_navigation::{
-            collect_focusable_nodes, find_focus_target, find_focused_node,
-        };
+        use crate::focus_navigation::{collect_focusable_nodes, find_focus_target};
 
         // Collect all focusable nodes
-        if let Ok(focusable_nodes) = collect_focusable_nodes(root) {
-            // Find the currently focused node
-            if let Some((current_id, current_rect)) =
-                find_focused_node(self, root, &focusable_nodes)
+        if let Ok((focusable_nodes, Some((current_id, current_rect)))) =
+            collect_focusable_nodes(self, root)
+        {
+            if let Some(target_id) =
+                find_focus_target(current_rect, dir, &focusable_nodes, &current_id)
             {
-                // Find the best target in the specified direction
-                if let Some(target_id) =
-                    find_focus_target(current_rect, dir, &focusable_nodes, &current_id)
-                {
-                    // Set focus on the target
-                    walk_to_root(root, &target_id, &mut |node| {
-                        if node.id() == target_id && node.accept_focus() {
-                            self.set_focus(node);
-                        }
-                        Ok(())
-                    })
-                    .unwrap();
-                }
+                // Set focus on the target
+                walk_to_root(root, &target_id, &mut |node| {
+                    if node.id() == target_id && node.accept_focus() {
+                        self.set_focus(node);
+                    }
+                    Ok(())
+                })
+                .unwrap();
             }
         }
     }

--- a/crates/canopy/src/focus_navigation.rs
+++ b/crates/canopy/src/focus_navigation.rs
@@ -34,10 +34,10 @@ pub fn collect_focusable_nodes(
         stack.push(vp);
 
         if let Some((_, screen_rect)) = stack.projection() {
+            if focused.is_none() && ctx.is_focused(node) {
+                *focused = Some((node.id(), screen_rect));
+            }
             if node.accept_focus() {
-                if focused.is_none() && ctx.is_focused(node) {
-                    *focused = Some((node.id(), screen_rect));
-                }
                 acc.push(FocusableNode {
                     id: node.id(),
                     rect: screen_rect,

--- a/crates/canopy/src/focus_navigation.rs
+++ b/crates/canopy/src/focus_navigation.rs
@@ -66,189 +66,36 @@ pub fn find_focus_target(
     candidates: &[FocusableNode],
     current_id: &NodeId,
 ) -> Option<NodeId> {
-    // Debug: print current rect
-    #[cfg(test)]
-    {
-        eprintln!("find_focus_target: current_rect = {current_rect:?}, direction = {direction:?}");
-        eprintln!("Total candidates: {}", candidates.len());
-    }
+    // Centre of the currently focused node
+    let cur_cx = current_rect.tl.x as i32 + current_rect.w as i32 / 2;
+    let cur_cy = current_rect.tl.y as i32 + current_rect.h as i32 / 2;
 
-    // Filter out the current node and nodes that don't make sense for the direction
-    let valid_candidates: Vec<&FocusableNode> = candidates
+    // Filter and sort candidates by how well they match the requested direction.
+    let mut candidates: Vec<&FocusableNode> = candidates
         .iter()
         .filter(|n| &n.id != current_id)
         .filter(|n| {
-            let in_dir = is_in_direction(&current_rect, &n.rect, direction);
-            #[cfg(test)]
-            {
-                if !in_dir
-                    && matches!(direction, Direction::Right)
-                    && n.rect.tl.x > current_rect.tl.x
-                {
-                    eprintln!("  Candidate at {:?} rejected by is_in_direction", n.rect);
-                }
+            let cx = n.rect.tl.x as i32 + n.rect.w as i32 / 2;
+            let cy = n.rect.tl.y as i32 + n.rect.h as i32 / 2;
+            match direction {
+                Direction::Right => cx > cur_cx,
+                Direction::Left => cx < cur_cx,
+                Direction::Down => cy > cur_cy,
+                Direction::Up => cy < cur_cy,
             }
-            in_dir
         })
         .collect();
 
-    #[cfg(test)]
-    eprintln!(
-        "Valid candidates after filtering: {}",
-        valid_candidates.len()
-    );
-
-    if valid_candidates.is_empty() {
-        return None;
-    }
-
-    // Find the best candidate based on direction
-
-    valid_candidates
-        .into_iter()
-        .min_by_key(|n| distance_score(&current_rect, &n.rect, direction))
-        .map(|n| n.id.clone())
-}
-
-/// Check if target is in the specified direction from source
-fn is_in_direction(source: &Rect, target: &Rect, direction: Direction) -> bool {
-    // Don't consider the exact same rectangle
-    if source == target {
-        return false;
-    }
-
-    match direction {
-        Direction::Right => {
-            // Accept nodes that are:
-            // 1. Strictly to the right (no overlap)
-            // 2. On the same row (overlapping Y) but extending further right
-            if target.tl.x >= source.tl.x + source.w {
-                // Strictly to the right
-                true
-            } else {
-                // Check if on same row and extends further right
-                let same_row = (target.tl.y < source.tl.y + source.h)
-                    && (target.tl.y + target.h > source.tl.y);
-                let extends_right = target.tl.x + target.w > source.tl.x + source.w;
-                same_row && extends_right
-            }
+    candidates.sort_by_key(|n| {
+        let cx = n.rect.tl.x as i32 + n.rect.w as i32 / 2;
+        let cy = n.rect.tl.y as i32 + n.rect.h as i32 / 2;
+        match direction {
+            Direction::Right => ((cy - cur_cy).abs(), cx - cur_cx),
+            Direction::Left => ((cy - cur_cy).abs(), cur_cx - cx),
+            Direction::Down => ((cx - cur_cx).abs(), cy - cur_cy),
+            Direction::Up => ((cx - cur_cx).abs(), cur_cy - cy),
         }
-        Direction::Left => {
-            // Accept nodes that are:
-            // 1. Strictly to the left (no overlap)
-            // 2. On the same row (overlapping Y) but extending further left
-            if target.tl.x + target.w <= source.tl.x {
-                // Strictly to the left
-                true
-            } else {
-                // Check if on same row and extends further left
-                let same_row = (target.tl.y < source.tl.y + source.h)
-                    && (target.tl.y + target.h > source.tl.y);
-                let extends_left = target.tl.x < source.tl.x;
-                same_row && extends_left
-            }
-        }
-        Direction::Down => {
-            // Accept nodes that are:
-            // 1. Strictly below (no overlap)
-            // 2. On the same column (overlapping X) but extending further down
-            if target.tl.y >= source.tl.y + source.h {
-                // Strictly below
-                true
-            } else {
-                // Check if in same column and extends further down
-                let same_col = (target.tl.x < source.tl.x + source.w)
-                    && (target.tl.x + target.w > source.tl.x);
-                let extends_down = target.tl.y + target.h > source.tl.y + source.h;
-                same_col && extends_down
-            }
-        }
-        Direction::Up => {
-            // Accept nodes that are:
-            // 1. Strictly above (no overlap)
-            // 2. On the same column (overlapping X) but extending further up
-            if target.tl.y + target.h <= source.tl.y {
-                // Strictly above
-                true
-            } else {
-                // Check if in same column and extends further up
-                let same_col = (target.tl.x < source.tl.x + source.w)
-                    && (target.tl.x + target.w > source.tl.x);
-                let extends_up = target.tl.y < source.tl.y;
-                same_col && extends_up
-            }
-        }
-    }
-}
+    });
 
-/// Calculate a distance score for ranking candidates
-/// Lower scores are better
-fn distance_score(source: &Rect, target: &Rect, direction: Direction) -> u32 {
-    match direction {
-        Direction::Right => {
-            // For rightward movement in a grid:
-            // 1. Prefer nodes on the same row (small y difference)
-            // 2. Among those, prefer the closest one to the right
-            let y_diff = source.tl.y.abs_diff(target.tl.y) as u32;
-            let x_dist = target.tl.x.saturating_sub(source.tl.x) as u32;
-
-            // If on same row (y_diff == 0), prioritize by x distance
-            // Otherwise, prioritize by row difference, then x distance
-            if y_diff == 0 {
-                x_dist
-            } else {
-                // Not on same row - add a large penalty
-                100000 + y_diff * 1000 + x_dist
-            }
-        }
-        Direction::Left => {
-            // For leftward movement in a grid:
-            // 1. Prefer nodes on the same row (small y difference)
-            // 2. Among those, prefer the closest one to the left
-            let y_diff = source.tl.y.abs_diff(target.tl.y) as u32;
-            let x_dist = source.tl.x.saturating_sub(target.tl.x) as u32;
-
-            // If on same row (y_diff == 0), prioritize by x distance
-            // Otherwise, prioritize by row difference, then x distance
-            if y_diff == 0 {
-                x_dist
-            } else {
-                // Not on same row - add a large penalty
-                100000 + y_diff * 1000 + x_dist
-            }
-        }
-        Direction::Down => {
-            // For downward movement in a grid:
-            // 1. Prefer nodes in the same column (small x difference)
-            // 2. Among those, prefer the closest one below
-            let x_diff = source.tl.x.abs_diff(target.tl.x) as u32;
-            let y_dist = target.tl.y.saturating_sub(source.tl.y) as u32;
-
-            // If in same column (x_diff == 0), prioritize by y distance
-            // Otherwise, prioritize by column difference, then y distance
-            if x_diff == 0 {
-                y_dist
-            } else {
-                // Not in same column - add a penalty, but less than for horizontal movement
-                // since we often want to find the closest node below even if not perfectly aligned
-                10000 + x_diff * 100 + y_dist
-            }
-        }
-        Direction::Up => {
-            // For upward movement in a grid:
-            // 1. Prefer nodes in the same column (small x difference)
-            // 2. Among those, prefer the closest one above
-            let x_diff = source.tl.x.abs_diff(target.tl.x) as u32;
-            let y_dist = source.tl.y.saturating_sub(target.tl.y) as u32;
-
-            // If in same column (x_diff == 0), prioritize by y distance
-            // Otherwise, prioritize by column difference, then y distance
-            if x_diff == 0 {
-                y_dist
-            } else {
-                // Not in same column - add a penalty
-                10000 + x_diff * 100 + y_dist
-            }
-        }
-    }
+    candidates.first().map(|n| n.id.clone())
 }

--- a/crates/canopy/tests/test_focus_navigation.rs
+++ b/crates/canopy/tests/test_focus_navigation.rs
@@ -385,6 +385,44 @@ fn test_snake_navigation_9x9_grid() -> Result<()> {
 }
 
 #[test]
+fn test_focus_bounds_2x2_grid() -> Result<()> {
+    let mut grid = Grid::new(1, 2);
+    let layout = Layout {};
+    let size = grid.expected_size();
+    grid.layout(&layout, size)?;
+
+    let mut canopy = Canopy::new();
+    canopy.focus_first(&mut grid);
+
+    // At top-left corner
+    assert_eq!(
+        get_focused_cell(&canopy, &mut grid),
+        Some("cell_0_0".to_string())
+    );
+    canopy.focus_left(&mut grid);
+    canopy.focus_up(&mut grid);
+    assert_eq!(
+        get_focused_cell(&canopy, &mut grid),
+        Some("cell_0_0".to_string()),
+        "Focus should not move beyond top-left"
+    );
+
+    canopy.focus_down(&mut grid); // to cell_0_1
+    canopy.focus_right(&mut grid); // to cell_1_1
+
+    // At bottom-right corner
+    canopy.focus_right(&mut grid);
+    canopy.focus_down(&mut grid);
+    assert_eq!(
+        get_focused_cell(&canopy, &mut grid),
+        Some("cell_1_1".to_string()),
+        "Focus should stay at bottom-right when moving beyond bounds"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_snake_navigation_8x8_grid() {
     // This test is expected to fail due to container boundary issues
     let mut grid = Grid::new(3, 2);


### PR DESCRIPTION
## Summary
- simplify focusable node collection using absolute offsets
- capture currently focused node while collecting
- streamline focus movement logic

## Testing
- `cargo clippy --examples --tests`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6864f07921f883338bb8688d33de4eed