### PR TITLE
Fix viewport projection clipping and child rendering

### DIFF
--- a/crates/canopy-widgets/src/frame.rs
+++ b/crates/canopy-widgets/src/frame.rs
@@ -244,8 +244,9 @@ mod tests {
                     line.push(ch);
                 }
 
-                // Use view.line like framegym does
-                r.text("text", view.line(y), &line)?;
+                let target_line =
+                    canopy_core::geom::Line::new(vp.position().x, vp.position().y + y, view.w);
+                r.text("text", target_line, &line)?;
             }
             Ok(())
         }


### PR DESCRIPTION
## Summary
- correct projection calculations to account for viewport position without including scroll offset
- render scrollable content using its viewport position so it doesn't draw over frame borders
- update projection tests for new semantics

## Testing
- `cargo clippy --examples --tests`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68688f97524883338ec7198d0215c950