### PR TITLE
Fix focusgym bottom row rendering

### DIFF
--- a/crates/canopy-widgets/src/frame.rs
+++ b/crates/canopy-widgets/src/frame.rs
@@ -244,8 +244,9 @@ mod tests {
                     line.push(ch);
                 }
 
-                // Use view.line like framegym does
-                r.text("text", view.line(y), &line)?;
+                let target_line =
+                    canopy_core::geom::Line::new(vp.position().x, vp.position().y + y, view.w);
+                r.text("text", target_line, &line)?;
             }
             Ok(())
         }

--- a/crates/canopy/src/backend/crossterm.rs
+++ b/crates/canopy/src/backend/crossterm.rs
@@ -156,8 +156,17 @@ impl CrosstermRender {
     }
 
     fn text(&mut self, loc: Point, txt: &str) -> io::Result<()> {
-        self.fp.queue(ccursor::MoveTo(loc.x, loc.y))?;
-        self.fp.queue(style::Print(txt))?;
+        let (w, h) = terminal::size()?;
+        let out = if loc.y == h.saturating_sub(1) && loc.x + txt.len() as u16 >= w {
+            let max = (w - 1).saturating_sub(loc.x) as usize;
+            &txt[..max]
+        } else {
+            txt
+        };
+        if !out.is_empty() {
+            self.fp.queue(ccursor::MoveTo(loc.x, loc.y))?;
+            self.fp.queue(style::Print(out))?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- avoid writing characters at the terminal bottom-right cell to prevent unintended scroll

## Testing
- `cargo clippy --examples --tests`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68688f97524883338ec7198d0215c950