### PR TITLE
Update geometry types

### DIFF
--- a/crates/canopy-core/src/context.rs
+++ b/crates/canopy-core/src/context.rs
@@ -48,7 +48,7 @@ pub trait Context {
     /// Scroll the view to the specified position. The view is clamped within
     /// the outer rectangle. Returns `true` if movement occurred and taints the
     /// subtree on change.
-    fn scroll_to(&mut self, n: &mut dyn Node, x: u16, y: u16) -> bool {
+    fn scroll_to(&mut self, n: &mut dyn Node, x: u32, y: u32) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_to(x, y);
         let changed = before != n.vp().view();
@@ -61,7 +61,7 @@ pub trait Context {
     /// Scroll the view by the given offsets. The view rectangle is clamped
     /// within the outer rectangle. Returns `true` if movement occurred and
     /// taints the subtree on change.
-    fn scroll_by(&mut self, n: &mut dyn Node, x: i16, y: i16) -> bool {
+    fn scroll_by(&mut self, n: &mut dyn Node, x: i32, y: i32) -> bool {
         let before = n.vp().view();
         n.state_mut().scroll_by(x, y);
         let changed = before != n.vp().view();

--- a/crates/canopy-core/src/error.rs
+++ b/crates/canopy-core/src/error.rs
@@ -1,5 +1,5 @@
-use std::{fmt::Display, sync::mpsc};
 use crate::geom;
+use std::{fmt::Display, sync::mpsc};
 
 use thiserror::Error;
 

--- a/crates/canopy-core/src/layout.rs
+++ b/crates/canopy-core/src/layout.rs
@@ -50,7 +50,7 @@ impl Layout {
         child.state_mut().set_position(
             parent_vp
                 .position()
-                .scroll(loc.tl.x as i16, loc.tl.y as i16),
+                .scroll(loc.tl.x as i32, loc.tl.y as i32),
         );
         child.layout(self, loc.expanse())?;
         Ok(())
@@ -89,12 +89,12 @@ mod tests {
     // Simple fixed-size test node
     struct TFixed {
         state: NodeState,
-        width: u16,
-        height: u16,
+        width: u32,
+        height: u32,
     }
 
     impl TFixed {
-        fn new(width: u16, height: u16) -> Self {
+        fn new(width: u32, height: u32) -> Self {
             TFixed {
                 state: NodeState::default(),
                 width,

--- a/crates/canopy-core/src/render.rs
+++ b/crates/canopy-core/src/render.rs
@@ -140,9 +140,9 @@ impl<'a> Render<'a> {
             // Pad with spaces if needed
             if out.len() < adjusted_line.w as usize {
                 let pad_rect = geom::Rect::new(
-                    adjusted_line.tl.x + out.len() as u16,
+                    adjusted_line.tl.x + out.len() as u32,
                     adjusted_line.tl.y,
-                    adjusted_line.w - out.len() as u16,
+                    adjusted_line.w - out.len() as u32,
                     1,
                 );
                 self.buf.fill(style_res, pad_rect, ' ');

--- a/crates/canopy-core/src/state.rs
+++ b/crates/canopy-core/src/state.rs
@@ -154,12 +154,12 @@ impl NodeState {
     }
 
     /// Scroll the view to the specified position.
-    pub fn scroll_to(&mut self, x: u16, y: u16) {
+    pub fn scroll_to(&mut self, x: u32, y: u32) {
         self.viewport.scroll_to(x, y);
     }
 
     /// Scroll the view by the given offsets.
-    pub fn scroll_by(&mut self, x: i16, y: i16) {
+    pub fn scroll_by(&mut self, x: i32, y: i32) {
         self.viewport.scroll_by(x, y);
     }
 

--- a/crates/canopy-core/src/termbuf.rs
+++ b/crates/canopy-core/src/termbuf.rs
@@ -83,14 +83,14 @@ impl TermBuf {
         // Intersect the destination rectangle with our bounds
         if let Some(clipped_dest) = self.rect().intersect(&dest_rect) {
             // Calculate the offset into the source buffer based on clipping
-            let src_offset_x = (clipped_dest.tl.x - dest_rect.tl.x) as i16;
-            let src_offset_y = (clipped_dest.tl.y - dest_rect.tl.y) as i16;
+            let src_offset_x = (clipped_dest.tl.x - dest_rect.tl.x) as i32;
+            let src_offset_y = (clipped_dest.tl.y - dest_rect.tl.y) as i32;
 
             // Copy the visible portion
             for dy in 0..clipped_dest.h {
                 for dx in 0..clipped_dest.w {
-                    let src_x = (dx as i16 + src_offset_x) as u16;
-                    let src_y = (dy as i16 + src_offset_y) as u16;
+                    let src_x = (dx as i32 + src_offset_x) as u32;
+                    let src_y = (dy as i32 + src_offset_y) as u32;
                     let src_p = Point { x: src_x, y: src_y };
 
                     if let Some(cell) = src.get(src_p) {
@@ -200,7 +200,7 @@ impl TermBuf {
     }
 
     /// Return the contents of a line as a `String`.
-    pub fn line_text(&self, y: u16) -> Option<String> {
+    pub fn line_text(&self, y: u32) -> Option<String> {
         if y >= self.size.h {
             return None;
         }
@@ -246,7 +246,7 @@ impl TermBuf {
 
     /// Does the buffer contain the supplied substring with the given style?
     pub fn contains_text_style(&self, txt: &str, style: &crate::style::PartialStyle) -> bool {
-        let tl = txt.chars().count() as u16;
+        let tl = txt.chars().count() as u32;
         if tl == 0 || tl > self.size.w {
             return false;
         }
@@ -255,7 +255,7 @@ impl TermBuf {
                 let mut m = true;
                 let mut c = false;
                 for (i, ch) in txt.chars().enumerate() {
-                    if let Some(cell) = self.get(Point { x: x + i as u16, y }) {
+                    if let Some(cell) = self.get(Point { x: x + i as u32, y }) {
                         if cell.ch != ch {
                             m = false;
                             break;
@@ -344,7 +344,7 @@ impl TermBuf {
             // Get actual line character by character to handle NULL cells
             let mut actual_chars = Vec::new();
             for x in 0..self.size.w {
-                if let Some(cell) = self.get(Point { x, y: y as u16 }) {
+                if let Some(cell) = self.get(Point { x, y: y as u32 }) {
                     if cell.ch == NULL {
                         actual_chars.push('X');
                     } else {

--- a/crates/canopy-core/src/tutils/grid.rs
+++ b/crates/canopy-core/src/tutils/grid.rs
@@ -160,15 +160,15 @@ impl Node for GridNode {
 
         if let GridNode::Container { children, .. } = self {
             let divisions = (children.len() as f64).sqrt() as usize;
-            let cell_width = sz.w / divisions as u16;
-            let cell_height = sz.h / divisions as u16;
+            let cell_width = sz.w / divisions as u32;
+            let cell_height = sz.h / divisions as u32;
 
             for (i, child) in children.iter_mut().enumerate() {
                 let row = i / divisions;
                 let col = i % divisions;
 
-                let x = col as u16 * cell_width;
-                let y = row as u16 * cell_height;
+                let x = col as u32 * cell_width;
+                let y = row as u32 * cell_height;
 
                 // Last cell in each row/column gets remaining space
                 let width = if col == divisions - 1 {
@@ -279,7 +279,7 @@ impl Grid {
         } else {
             self.divisions.pow(self.recursion as u32)
         };
-        let size = cells_per_side as u16 * 10; // Each cell is 10x10
+        let size = cells_per_side as u32 * 10; // Each cell is 10x10
         Expanse::new(size, size)
     }
 
@@ -295,7 +295,7 @@ impl Grid {
     }
 
     /// Helper to find the deepest leaf node at a given position
-    pub fn find_leaf_at(&mut self, x: u16, y: u16) -> Option<String> {
+    pub fn find_leaf_at(&mut self, x: u32, y: u32) -> Option<String> {
         // Keep track of all nodes we encounter
         let mut nodes = Vec::new();
         locate(self, (x, y), &mut |node| -> Result<Locate<()>> {

--- a/crates/canopy-core/src/viewport.rs
+++ b/crates/canopy-core/src/viewport.rs
@@ -94,7 +94,7 @@ impl ViewPort {
 
     /// Scroll the view to the specified position. The view is clamped within
     /// the outer rectangle.
-    pub(crate) fn scroll_to(&mut self, x: u16, y: u16) {
+    pub(crate) fn scroll_to(&mut self, x: u32, y: u32) {
         let r = Rect::new(x, y, self.view.w, self.view.h);
         // We unwrap here, because this can only be an error if view is larger
         // than outer, which we ensure is not the case.
@@ -103,18 +103,18 @@ impl ViewPort {
 
     /// Scroll the view by the given offsets. The view rectangle is clamped
     /// within the outer rectangle.
-    pub(crate) fn scroll_by(&mut self, x: i16, y: i16) {
+    pub(crate) fn scroll_by(&mut self, x: i32, y: i32) {
         self.view = self.view.shift_within(x, y, self.canvas.rect());
     }
 
     /// Scroll the view up by the height of the view rectangle.
     pub(crate) fn page_up(&mut self) {
-        self.scroll_by(0, -(self.view.h as i16))
+        self.scroll_by(0, -(self.view.h as i32))
     }
 
     /// Scroll the view down by the height of the view rectangle.
     pub(crate) fn page_down(&mut self) {
-        self.scroll_by(0, self.view.h as i16)
+        self.scroll_by(0, self.view.h as i32)
     }
 
     /// Scroll the view up by one line.

--- a/crates/canopy-core/src/viewstack.rs
+++ b/crates/canopy-core/src/viewstack.rs
@@ -124,7 +124,7 @@ impl ViewStack {
                 let rect_on_screen = Rect {
                     tl: current_screen
                         .tl
-                        .scroll(rebased.tl.x as i16, rebased.tl.y as i16),
+                        .scroll(rebased.tl.x as i32, rebased.tl.y as i32),
                     w: rebased.w,
                     h: rebased.h,
                 };
@@ -165,10 +165,10 @@ impl ViewStack {
                         tl: visible_part
                             .tl
                             .scroll(
-                                -(viewport.position().x as i16),
-                                -(viewport.position().y as i16),
+                                -(viewport.position().x as i32),
+                                -(viewport.position().y as i32),
                             )
-                            .scroll(viewport.view().tl.x as i16, viewport.view().tl.y as i16),
+                            .scroll(viewport.view().tl.x as i32, viewport.view().tl.y as i32),
                         w: visible_part.w,
                         h: visible_part.h,
                     };
@@ -199,8 +199,8 @@ mod tests {
 
     struct TestCase {
         name: &'static str,
-        viewports: Vec<((u16, u16), (u16, u16, u16, u16), (u16, u16))>,
-        projections: Vec<Option<((u16, u16, u16, u16), (u16, u16, u16, u16))>>,
+        viewports: Vec<((u32, u32), (u32, u32, u32, u32), (u32, u32))>,
+        projections: Vec<Option<((u32, u32, u32, u32), (u32, u32, u32, u32))>>,
     }
 
     impl TestCase {

--- a/crates/canopy-core/tests/test_grid_dimensions.rs
+++ b/crates/canopy-core/tests/test_grid_dimensions.rs
@@ -25,7 +25,7 @@ fn test_grid_dimensions() {
 
         // Also verify that dimensions match expected_size
         let expected_size = grid.expected_size();
-        let expected_pixels = (expected.0 as u16 * 10, expected.1 as u16 * 10);
+        let expected_pixels = (expected.0 as u32 * 10, expected.1 as u32 * 10);
         assert_eq!(
             (expected_size.w, expected_size.h),
             expected_pixels,

--- a/crates/canopy-widgets/src/editor/editor_impl.rs
+++ b/crates/canopy-widgets/src/editor/editor_impl.rs
@@ -43,14 +43,14 @@ impl Node for EditorView {
         self.core.resize_window(sr.w as usize, sr.h as usize);
         for (i, s) in self.core.window_text().iter().enumerate() {
             if let Some(t) = s {
-                r.text("text", vo.line(i as u16), t)?;
+                r.text("text", vo.line(i as u32), t)?;
             }
         }
         Ok(())
     }
 
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
-        let outer = Expanse::new(sz.w, self.core.wrapped_height() as u16);
+        let outer = Expanse::new(sz.w, self.core.wrapped_height() as u32);
         l.size(self, outer, sz)?;
         Ok(())
     }

--- a/crates/canopy-widgets/src/editor/state.rs
+++ b/crates/canopy-widgets/src/editor/state.rs
@@ -288,13 +288,13 @@ impl State {
                 let (lstart, lend) = self.chunks[l.chunk].wraps[l.wrap_idx];
                 if c.len() == 0 && l.chunk == pos.chunk {
                     // We're at the first character of an empty chunk.
-                    return Some((0, y as u16).into());
+                    return Some((0, y as u32).into());
                 } else if pos.offset >= c.len() && l.chunk > pos.chunk {
                     // We're beyond the end of the chunk, which means we must be an insertion cursor. Place the cursor
                     // position at the first character of the next line.
-                    return Some((0, y as u16).into());
+                    return Some((0, y as u32).into());
                 } else if l.chunk == pos.chunk && lstart <= pos.offset && lend > pos.offset {
-                    return Some(((pos.offset - lstart) as u16, y as u16).into());
+                    return Some(((pos.offset - lstart) as u32, y as u32).into());
                 }
             }
         }
@@ -384,13 +384,13 @@ mod tests {
                 let w = w.unwrap();
                 let s = if let Some(x) = split[i].find("_") {
                     let cp = cp.unwrap();
-                    assert_eq!(cp.x, x as u16);
-                    assert_eq!(cp.y, i as u16);
+                    assert_eq!(cp.x, x as u32);
+                    assert_eq!(cp.y, i as u32);
                     split[i].replace("_", "")
                 } else if let Some(x) = split[i].find("<") {
                     let cp = cp.unwrap();
-                    assert_eq!(cp.x, (x - 1) as u16);
-                    assert_eq!(cp.y, i as u16);
+                    assert_eq!(cp.x, (x - 1) as u32);
+                    assert_eq!(cp.y, i as u32);
                     split[i].replace("<", "")
                 } else {
                     split[i].into()

--- a/crates/canopy-widgets/src/frame.rs
+++ b/crates/canopy-widgets/src/frame.rs
@@ -185,7 +185,7 @@ mod tests {
     }
 
     impl ScrollableContent {
-        fn new(width: u16, height: u16) -> Self {
+        fn new(width: u32, height: u32) -> Self {
             ScrollableContent {
                 state: NodeState::default(),
                 canvas_size: Expanse::new(width, height),
@@ -239,7 +239,7 @@ mod tests {
                     }
 
                     // Simple pattern: character based on position
-                    let ch = char::from_u32(((absolute_x + absolute_y) % 10) as u32 + '0' as u32)
+                    let ch = char::from_u32(((absolute_x + absolute_y) % 10) + '0' as u32)
                         .unwrap_or('?');
                     line.push(ch);
                 }
@@ -392,11 +392,11 @@ mod tests {
                 true
             }
             fn focus_dir(&mut self, _root: &mut dyn Node, _dir: Direction) {}
-            fn scroll_to(&mut self, n: &mut dyn Node, x: u16, y: u16) -> bool {
+            fn scroll_to(&mut self, n: &mut dyn Node, x: u32, y: u32) -> bool {
                 n.state_mut().scroll_to(x, y);
                 true
             }
-            fn scroll_by(&mut self, n: &mut dyn Node, x: i16, y: i16) -> bool {
+            fn scroll_by(&mut self, n: &mut dyn Node, x: i32, y: i32) -> bool {
                 n.state_mut().scroll_by(x, y);
                 true
             }
@@ -498,7 +498,7 @@ mod tests {
             if let Some((_canvas_rect, screen_rect)) = view_stack.projection() {
                 println!("Frame projection: screen_rect={:?}", screen_rect);
                 let frame_buf = frame_render.get_buffer();
-                main_buf.copy_to_rect(&frame_buf, screen_rect);
+                main_buf.copy_to_rect(frame_buf, screen_rect);
             }
 
             // 2. Then render each child
@@ -530,7 +530,7 @@ mod tests {
                         );
                         let child_buf = child_render.get_buffer();
                         println!("Child buffer first line: {:?}", child_buf.line_text(0));
-                        main_buf.copy_to_rect(&child_buf, screen_rect);
+                        main_buf.copy_to_rect(child_buf, screen_rect);
                     } else {
                         println!("No projection for child!");
                     }
@@ -591,11 +591,11 @@ mod tests {
                 true
             }
             fn focus_dir(&mut self, _root: &mut dyn Node, _dir: Direction) {}
-            fn scroll_to(&mut self, n: &mut dyn Node, x: u16, y: u16) -> bool {
+            fn scroll_to(&mut self, n: &mut dyn Node, x: u32, y: u32) -> bool {
                 n.state_mut().scroll_to(x, y);
                 true
             }
-            fn scroll_by(&mut self, n: &mut dyn Node, x: i16, y: i16) -> bool {
+            fn scroll_by(&mut self, n: &mut dyn Node, x: i32, y: i32) -> bool {
                 n.state_mut().scroll_by(x, y);
                 true
             }
@@ -696,7 +696,7 @@ mod tests {
             }
 
             // Check for overdraw
-            check_frame_boundaries(&buffer, test_name);
+            check_frame_boundaries(buffer, test_name);
         }
 
         // Also test incremental scrolling
@@ -718,7 +718,7 @@ mod tests {
                 .unwrap();
 
             let buffer = render.get_buffer();
-            check_frame_boundaries(&buffer, &format!("After {} scroll_down calls", i + 1));
+            check_frame_boundaries(buffer, &format!("After {} scroll_down calls", i + 1));
         }
 
         // Scroll right one column at a time
@@ -735,7 +735,7 @@ mod tests {
                 .unwrap();
 
             let buffer = render.get_buffer();
-            check_frame_boundaries(&buffer, &format!("After {} scroll_right calls", i + 1));
+            check_frame_boundaries(buffer, &format!("After {} scroll_right calls", i + 1));
         }
     }
 }

--- a/crates/canopy-widgets/src/input.rs
+++ b/crates/canopy-widgets/src/input.rs
@@ -14,7 +14,7 @@ use canopy_core::{
 pub struct TextBuf {
     pub value: String,
 
-    cursor_pos: u16,
+    cursor_pos: u32,
     window: LineSegment,
 }
 
@@ -22,26 +22,26 @@ impl TextBuf {
     fn new(start: &str) -> Self {
         TextBuf {
             value: start.to_owned(),
-            cursor_pos: start.len() as u16,
+            cursor_pos: start.len() as u32,
             window: LineSegment { off: 0, len: 0 },
         }
     }
 
     /// The location of the displayed cursor along the x axis
-    fn cursor_display(&self) -> u16 {
+    fn cursor_display(&self) -> u32 {
         self.cursor_pos - self.window.off
     }
 
     fn text(&self) -> String {
-        let end = self.window.far().min(self.value.len() as u16) as usize;
+        let end = self.window.far().min(self.value.len() as u32) as usize;
         let v = self.value[self.window.off as usize..end].to_owned();
         let extra = self.window.len as usize - v.len();
         format!("{}{}", v, " ".repeat(extra))
     }
 
     fn fix_window(&mut self) {
-        if self.cursor_pos > self.value.len() as u16 {
-            self.cursor_pos = self.value.len() as u16
+        if self.cursor_pos > self.value.len() as u32 {
+            self.cursor_pos = self.value.len() as u32
         }
         if self.cursor_pos < self.window.off {
             self.window.off = self.cursor_pos;
@@ -49,7 +49,7 @@ impl TextBuf {
             let mut off = self.cursor_pos - self.window.len;
             // When we're right at the end of the sequence, we need one extra
             // character for the cursor.
-            if self.cursor_pos == self.value.len() as u16 {
+            if self.cursor_pos == self.value.len() as u32 {
                 off += 1
             }
             self.window.off = off;
@@ -65,11 +65,11 @@ impl TextBuf {
     fn set_display_width(&mut self, val: usize) {
         self.window = LineSegment {
             off: self.window.off,
-            len: val as u16,
+            len: val as u32,
         };
     }
 
-    pub fn goto(&mut self, loc: u16) -> bool {
+    pub fn goto(&mut self, loc: u32) -> bool {
         let changed = self.cursor_pos != loc;
         self.cursor_pos = loc;
         self.fix_window();
@@ -101,7 +101,7 @@ impl TextBuf {
         }
     }
     pub fn right(&mut self) -> bool {
-        if self.cursor_pos < self.value.len() as u16 {
+        if self.cursor_pos < self.value.len() as u32 {
             self.cursor_pos += 1;
             self.fix_window();
             true
@@ -199,7 +199,7 @@ impl Node for Input {
 
     fn layout(&mut self, l: &Layout, sz: Expanse) -> Result<()> {
         self.textbuf.set_display_width(sz.w as usize);
-        let tbl = self.textbuf.value.len() as u16;
+        let tbl = self.textbuf.value.len() as u32;
         let expanse = if self.textbuf.window.len >= tbl {
             sz
         } else {

--- a/crates/canopy-widgets/src/list.rs
+++ b/crates/canopy-widgets/src/list.rs
@@ -147,7 +147,7 @@ where
             // position so remaining items stay visible.
             let vp_y = self.vp().view().tl.y;
             if itm.virt.tl.y < vp_y {
-                core.scroll_by(self, 0, -(itm.virt.h as i16));
+                core.scroll_by(self, 0, -(itm.virt.h as i32));
             }
             if self.ensure_selected_in_view(core) {
                 core.taint(self);

--- a/crates/canopy-widgets/src/panes.rs
+++ b/crates/canopy-widgets/src/panes.rs
@@ -80,10 +80,10 @@ where
     }
 
     /// Returns the shape of the current child grid
-    fn shape(&self) -> Vec<u16> {
+    fn shape(&self) -> Vec<u32> {
         let mut ret = vec![];
         for i in &self.children {
-            ret.push(i.len() as u16)
+            ret.push(i.len() as u32)
         }
         ret
     }

--- a/crates/canopy-widgets/src/tabs.rs
+++ b/crates/canopy-widgets/src/tabs.rs
@@ -42,7 +42,7 @@ impl Node for Tabs {
         for (i, rect) in self
             .vp()
             .view()
-            .split_horizontal(self.tabs.len() as u16)?
+            .split_horizontal(self.tabs.len() as u32)?
             .iter()
             .enumerate()
         {

--- a/crates/canopy-widgets/src/text.rs
+++ b/crates/canopy-widgets/src/text.rs
@@ -10,7 +10,7 @@ pub struct Text {
     pub state: NodeState,
     pub raw: String,
     lines: Option<Vec<String>>,
-    fixed_width: Option<u16>,
+    fixed_width: Option<u32>,
     current_size: Expanse,
 }
 
@@ -27,7 +27,7 @@ impl Text {
         }
     }
     /// Add a fixed width, ignoring fit parameters
-    pub fn with_fixed_width(mut self, width: u16) -> Self {
+    pub fn with_fixed_width(mut self, width: u32) -> Self {
         self.fixed_width = Some(width);
         self
     }
@@ -83,7 +83,7 @@ impl Node for Text {
             }
             self.current_size = Expanse {
                 w,
-                h: split.len() as u16,
+                h: split.len() as u32,
             };
             self.lines = Some(split);
         }

--- a/crates/canopy/examples/focusgym.rs
+++ b/crates/canopy/examples/focusgym.rs
@@ -56,9 +56,9 @@ impl Node for Block {
         self.fill(sz)?;
         if !self.children.is_empty() {
             let vps = if self.horizontal {
-                sz.rect().split_horizontal(self.children.len() as u16)?
+                sz.rect().split_horizontal(self.children.len() as u32)?
             } else {
-                sz.rect().split_vertical(self.children.len() as u16)?
+                sz.rect().split_vertical(self.children.len() as u32)?
             };
             for (i, child) in self.children.iter_mut().enumerate() {
                 l.place_(child, vps[i])?;

--- a/crates/canopy/examples/framegym.rs
+++ b/crates/canopy/examples/framegym.rs
@@ -49,10 +49,10 @@ impl TestPattern {
         c.page_up(self);
     }
 
-    fn generate_pattern_char(x: u16, y: u16) -> char {
+    fn generate_pattern_char(x: u32, y: u32) -> char {
         // Pattern: "abcdefghijklmnopqrstuvwxyz0123456789"
         let pattern = "abcdefghijklmnopqrstuvwxyz0123456789";
-        let pattern_len = pattern.len() as u16;
+        let pattern_len = pattern.len() as u32;
 
         // Offset each row by one more character than the previous
         let index = ((x + y) % pattern_len) as usize;

--- a/crates/canopy/src/backend/crossterm.rs
+++ b/crates/canopy/src/backend/crossterm.rs
@@ -156,7 +156,7 @@ impl CrosstermRender {
     }
 
     fn text(&mut self, loc: Point, txt: &str) -> io::Result<()> {
-        self.fp.queue(ccursor::MoveTo(loc.x, loc.y))?;
+        self.fp.queue(ccursor::MoveTo(loc.x as u16, loc.y as u16))?;
         self.fp.queue(style::Print(txt))?;
         Ok(())
     }
@@ -302,13 +302,13 @@ fn translate_event(e: cevent::Event) -> Event {
                 button,
                 action,
                 location: Point {
-                    x: m.column,
-                    y: m.row,
+                    x: m.column as u32,
+                    y: m.row as u32,
                 },
                 modifiers: translate_key_modifiers(m.modifiers),
             })
         }
-        cevent::Event::Resize(x, y) => Event::Resize(Expanse::new(x, y)),
+        cevent::Event::Resize(x, y) => Event::Resize(Expanse::new(x as u32, y as u32)),
         cevent::Event::FocusGained => Event::FocusGained,
         cevent::Event::FocusLost => Event::FocusLost,
         cevent::Event::Paste(s) => Event::Paste(s),
@@ -424,7 +424,7 @@ where
     event_emitter(cnpy.event_tx.clone());
     let size = translate_result(terminal::size())?;
     cnpy.register_backend(ctrl);
-    cnpy.set_root_size(Expanse::new(size.0, size.1), &mut root)?;
+    cnpy.set_root_size(Expanse::new(size.0 as u32, size.1 as u32), &mut root)?;
     cnpy.start_poller(cnpy.event_tx.clone());
 
     if let Err(e) = cnpy.render(&mut be, &mut root) {

--- a/crates/canopy/src/tutils/mod.rs
+++ b/crates/canopy/src/tutils/mod.rs
@@ -17,8 +17,8 @@ use canopy_core::{
 #[derive(Debug, PartialEq, Eq, StatefulNode)]
 pub struct TFixed {
     state: NodeState,
-    pub w: u16,
-    pub h: u16,
+    pub w: u32,
+    pub h: u32,
 }
 
 impl Node for TFixed {
@@ -31,7 +31,7 @@ impl Node for TFixed {
 
 #[derive_commands]
 impl TFixed {
-    pub fn new(w: u16, h: u16) -> Self {
+    pub fn new(w: u32, h: u32) -> Self {
         TFixed {
             state: NodeState::default(),
             w,
@@ -68,10 +68,10 @@ impl Context for DummyContext {
         false
     }
     fn focus_dir(&mut self, _root: &mut dyn Node, _dir: Direction) {}
-    fn scroll_to(&mut self, _n: &mut dyn Node, _x: u16, _y: u16) -> bool {
+    fn scroll_to(&mut self, _n: &mut dyn Node, _x: u32, _y: u32) -> bool {
         false
     }
-    fn scroll_by(&mut self, _n: &mut dyn Node, _x: i16, _y: i16) -> bool {
+    fn scroll_by(&mut self, _n: &mut dyn Node, _x: i32, _y: i32) -> bool {
         false
     }
     fn page_up(&mut self, _n: &mut dyn Node) -> bool {
@@ -163,9 +163,9 @@ mod tests {
             if !self.children.is_empty() {
                 let vp = self.vp();
                 let vps = if self.horizontal {
-                    vp.view().split_horizontal(self.children.len() as u16)?
+                    vp.view().split_horizontal(self.children.len() as u32)?
                 } else {
-                    vp.view().split_vertical(self.children.len() as u16)?
+                    vp.view().split_vertical(self.children.len() as u32)?
                 };
                 for (i, ch) in self.children.iter_mut().enumerate() {
                     l.place(ch, vp, vps[i])?;
@@ -224,9 +224,9 @@ mod tests {
             return Ok(vec![area]);
         }
         let vps = if b.horizontal {
-            area.split_horizontal(b.children.len() as u16)?
+            area.split_horizontal(b.children.len() as u32)?
         } else {
-            area.split_vertical(b.children.len() as u16)?
+            area.split_vertical(b.children.len() as u32)?
         };
         let mut ret = Vec::new();
         for (child, rect) in b.children.iter().zip(vps.into_iter()) {

--- a/crates/canopy/tests/test_render.rs
+++ b/crates/canopy/tests/test_render.rs
@@ -63,10 +63,10 @@ impl BufTest {
             !self.expected.is_empty(),
             "Cannot calculate buffer size from empty expected buffer"
         );
-        Expanse::new(self.expected[0].len() as u16, self.expected.len() as u16)
+        Expanse::new(self.expected[0].len() as u32, self.expected.len() as u32)
     }
 
-    fn line(mut self, x: u16, y: u16, width: u16, text: &'static str) -> Self {
+    fn line(mut self, x: u32, y: u32, width: u32, text: &'static str) -> Self {
         self.line = geom::Line {
             tl: geom::Point { x, y },
             w: width,

--- a/crates/canopy/tests/test_tree.rs
+++ b/crates/canopy/tests/test_tree.rs
@@ -270,7 +270,7 @@ fn test_postorder() -> Result<()> {
 }
 
 // Helper function to test locate on a grid at a specific point
-fn test_locate_at_point(grid: &mut Grid, point: (u16, u16), expected_name: &str) -> Result<()> {
+fn test_locate_at_point(grid: &mut Grid, point: (u32, u32), expected_name: &str) -> Result<()> {
     let result = locate(grid, point, &mut |node| -> Result<Locate<String>> {
         let name = node.name().to_string();
         if name.starts_with("cell_") {
@@ -361,8 +361,8 @@ fn test_locate_3x3_grid() -> Result<()> {
     // Test all 9 cells systematically
     for row in 0..3 {
         for col in 0..3 {
-            let x = col as u16 * 10 + 5;
-            let y = row as u16 * 10 + 5;
+            let x = col as u32 * 10 + 5;
+            let y = row as u32 * 10 + 5;
             let expected = format!("cell_{col}_{row}");
             test_locate_at_point(&mut grid, (x, y), &expected)?;
         }

--- a/crates/geom/src/expanse.rs
+++ b/crates/geom/src/expanse.rs
@@ -5,8 +5,8 @@ use super::{Point, Rect};
 /// to madate that the location of a `Rect` is (0, 0).
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Expanse {
-    pub w: u16,
-    pub h: u16,
+    pub w: u32,
+    pub h: u32,
 }
 
 impl Default for Expanse {
@@ -17,13 +17,13 @@ impl Default for Expanse {
 }
 
 impl Expanse {
-    pub fn new(w: u16, h: u16) -> Expanse {
+    pub fn new(w: u32, h: u32) -> Expanse {
         Expanse { w, h }
     }
 
     /// The area of this expanse.
     pub fn area(&self) -> u32 {
-        self.w as u32 * self.h as u32
+        self.w * self.h
     }
 
     /// Return a `Rect` with the same dimensions as the `Expanse`, but a location at (0, 0).
@@ -46,8 +46,8 @@ impl From<Rect> for Expanse {
     }
 }
 
-impl From<(u16, u16)> for Expanse {
-    fn from(v: (u16, u16)) -> Expanse {
+impl From<(u32, u32)> for Expanse {
+    fn from(v: (u32, u32)) -> Expanse {
         Expanse { w: v.0, h: v.1 }
     }
 }

--- a/crates/geom/src/frame.rs
+++ b/crates/geom/src/frame.rs
@@ -22,13 +22,13 @@ pub struct Frame {
     /// The original outer rect
     outer_rect: Rect,
     /// The border width
-    border: u16,
+    border: u32,
 }
 
 impl Frame {
     /// Construct a new frame. If the rect is too small to fit the specified
     /// frame, we return a zero Frame.
-    pub fn new(rect: Rect, border: u16) -> Self {
+    pub fn new(rect: Rect, border: u32) -> Self {
         if rect.w <= (border * 2) || rect.h <= (border * 2) {
             let mut f = Frame::zero();
             f.outer_rect = rect;

--- a/crates/geom/src/lib.rs
+++ b/crates/geom/src/lib.rs
@@ -1,18 +1,18 @@
+mod error;
 mod expanse;
 mod frame;
 mod line;
 mod linesegment;
 mod point;
 mod rect;
-mod error;
 
+pub use error::{Error, Result};
 pub use expanse::Expanse;
 pub use frame::Frame;
 pub use line::Line;
 pub use linesegment::LineSegment;
 pub use point::Point;
 pub use rect::Rect;
-pub use error::{Error, Result};
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Direction {

--- a/crates/geom/src/line.rs
+++ b/crates/geom/src/line.rs
@@ -4,7 +4,7 @@ use super::{Point, Rect};
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Line {
     pub tl: Point,
-    pub w: u16,
+    pub w: u32,
 }
 
 impl Default for Line {
@@ -18,7 +18,7 @@ impl Default for Line {
 }
 
 impl Line {
-    pub fn new(x: u16, y: u16, w: u16) -> Line {
+    pub fn new(x: u32, y: u32, w: u32) -> Line {
         Line {
             tl: Point { x, y },
             w,

--- a/crates/geom/src/linesegment.rs
+++ b/crates/geom/src/linesegment.rs
@@ -4,14 +4,14 @@ use crate::{Error, Result};
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct LineSegment {
     /// The offset of this extent.
-    pub off: u16,
+    pub off: u32,
     /// The length of this extent.
-    pub len: u16,
+    pub len: u32,
 }
 
 impl LineSegment {
     /// The far limit of the extent.
-    pub fn far(&self) -> u16 {
+    pub fn far(&self) -> u32 {
         self.off + self.len
     }
 
@@ -28,7 +28,7 @@ impl LineSegment {
     /// Carve off a fixed-size portion from the start of this LineSegment,
     /// returning a (head, tail) tuple. If the segment is too short to carve out
     /// the width specified, the length of the head will be zero.
-    pub fn carve_start(&self, n: u16) -> (LineSegment, LineSegment) {
+    pub fn carve_start(&self, n: u32) -> (LineSegment, LineSegment) {
         if self.len < n {
             (
                 LineSegment {
@@ -54,7 +54,7 @@ impl LineSegment {
     /// Carve off a fixed-size portion from the end of this LineSegment,
     /// returning a (head, tail) tuple. If the segment is too short to carve out
     /// the width specified, the length of the tail will be zero.
-    pub fn carve_end(&self, n: u16) -> (LineSegment, LineSegment) {
+    pub fn carve_end(&self, n: u32) -> (LineSegment, LineSegment) {
         if self.len < n {
             (
                 *self,
@@ -147,15 +147,15 @@ impl LineSegment {
             Ok((
                 LineSegment {
                     off: self.off,
-                    len: pre as u16,
+                    len: pre as u32,
                 },
                 LineSegment {
-                    off: self.off + pre as u16,
-                    len: active as u16,
+                    off: self.off + pre as u32,
+                    len: active as u32,
                 },
                 LineSegment {
-                    off: self.off + pre as u16 + active as u16,
-                    len: post as u16,
+                    off: self.off + pre as u32 + active as u32,
+                    len: post as u32,
                 },
             ))
         }

--- a/crates/geom/src/point.rs
+++ b/crates/geom/src/point.rs
@@ -4,8 +4,8 @@ use super::Rect;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct Point {
-    pub x: u16,
-    pub y: u16,
+    pub x: u32,
+    pub y: u32,
 }
 
 impl Point {
@@ -16,7 +16,7 @@ impl Point {
         self.x == 0 && self.y == 0
     }
     /// Shift the point by an offset, avoiding under- or overflow.
-    pub fn scroll(&self, x: i16, y: i16) -> Self {
+    pub fn scroll(&self, x: i32, y: i32) -> Self {
         let nx = if x < 0 {
             self.x.saturating_sub(x.unsigned_abs())
         } else {
@@ -37,7 +37,7 @@ impl Point {
         }
     }
     /// Like scroll, but constrained within a rectangle.
-    pub fn scroll_within(&self, x: i16, y: i16, rect: Rect) -> Self {
+    pub fn scroll_within(&self, x: i32, y: i32, rect: Rect) -> Self {
         let nx = if x < 0 {
             self.x.saturating_sub(x.unsigned_abs())
         } else {
@@ -63,9 +63,9 @@ impl Add for Point {
     }
 }
 
-impl From<(u16, u16)> for Point {
+impl From<(u32, u32)> for Point {
     #[inline]
-    fn from(v: (u16, u16)) -> Point {
+    fn from(v: (u32, u32)) -> Point {
         Point { x: v.0, y: v.1 }
     }
 }


### PR DESCRIPTION
## Summary
- use `u32` and `i32` for geom types
- update viewport and widgets to match
- convert backend to use new geometry types
- adjust tests and examples

## Testing
- `cargo clippy --fix --allow-dirty --examples --tests --all`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6868ac5111b48333a31babff1c99c513